### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -1,0 +1,33 @@
+name: Python Poetry Build
+
+on: [push]
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8"]
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Install Dependencies
+        run: poetry install
+        if: steps.cache.outputs.cache-hit != 'true'
+
+      - name: Code Quality
+        run: poetry run black . --check
+
+      - name: Test with pytest
+        run: poetry run pytest

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v1
         with:

--- a/gimie/__init__.py
+++ b/gimie/__init__.py
@@ -2,13 +2,13 @@
 # Copyright 2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/gimie/sources/files.py
+++ b/gimie/sources/files.py
@@ -2,13 +2,13 @@
 # Copyright 2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/gimie/sources/git.py
+++ b/gimie/sources/git.py
@@ -66,7 +66,12 @@ class GitMetadata:
     @cached_property
     def authors(self) -> Tuple[str]:
         """Get the authors of the repository."""
-        return tuple(set(commit.author.name for commit in self.repository.traverse_commits()))
+        return tuple(
+            set(
+                commit.author.name
+                for commit in self.repository.traverse_commits()
+            )
+        )
 
     @cached_property
     def creation_date(self) -> Optional[datetime.datetime]:
@@ -90,8 +95,14 @@ class GitMetadata:
         try:
             # This is necessary to initialize the repository
             next(self.repository.traverse_commits())
-            releases = tuple(Release(tag=tag.name, date=tag.commit.authored_datetime,
-                                     commit_hash=tag.commit.hexsha) for tag in self.repository.git.repo.tags)
+            releases = tuple(
+                Release(
+                    tag=tag.name,
+                    date=tag.commit.authored_datetime,
+                    commit_hash=tag.commit.hexsha,
+                )
+                for tag in self.repository.git.repo.tags
+            )
             return sorted(releases)
         except StopIteration:
             return None

--- a/gimie/sources/license.py
+++ b/gimie/sources/license.py
@@ -2,13 +2,13 @@
 # Copyright 2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,0 @@
-"""Avoid _pytest.pathlib.ImportPathMismatchError for pytest"""
-import os
-
-os.environ["PY_IGNORE_IMPORTMISMATCH"] = "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+"""Avoid _pytest.pathlib.ImportPathMismatchError for pytest"""
+import os
+os.environ["PY_IGNORE_IMPORTMISMATCH"] = "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+"""Avoid _pytest.pathlib.ImportPathMismatchError for pytest"""
+import os
+
+os.environ["PY_IGNORE_IMPORTMISMATCH"] = "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
 """Avoid _pytest.pathlib.ImportPathMismatchError for pytest"""
 import os
+
 os.environ["PY_IGNORE_IMPORTMISMATCH"] = "1"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -21,8 +21,11 @@ def test_git_authors():
 def test_git_creation_date():
     """Test the creation date of a git repository."""
     git_metadata = GitMetadata(LOCAL_REPOSITORY)
-    assert git_metadata.creation_date.astimezone(datetime.timezone.utc) == datetime.datetime(
-        2022, 12, 7, 10, 19, 31, tzinfo=datetime.timezone.utc)
+    assert git_metadata.creation_date.astimezone(
+        datetime.timezone.utc
+    ) == datetime.datetime(
+        2022, 12, 7, 10, 19, 31, tzinfo=datetime.timezone.utc
+    )
 
 
 def test_git_creator():
@@ -36,6 +39,11 @@ def test_git_releases():
     git_metadata = GitMetadata(RENKU_REPOSITORY)
     first_release = git_metadata.releases[0]
     assert first_release.tag == "maint-0.1"
-    assert first_release.date.astimezone(datetime.timezone.utc) == datetime.datetime(
-        2018, 2, 16, 20, 40, 10, tzinfo=datetime.timezone.utc)
-    assert first_release.commit_hash == "615132e9c0c0e6e139f566c4066a17af93651b55"
+    assert first_release.date.astimezone(
+        datetime.timezone.utc
+    ) == datetime.datetime(
+        2018, 2, 16, 20, 40, 10, tzinfo=datetime.timezone.utc
+    )
+    assert (
+        first_release.commit_hash == "615132e9c0c0e6e139f566c4066a17af93651b55"
+    )

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4,7 +4,7 @@ from gimie.sources.git import GitMetadata
 import datetime
 import pytest
 
-LOCAL_REPOSITORY = ".."
+LOCAL_REPOSITORY = "https://github.com/SDSC-ORD/gimie"
 RENKU_REPOSITORY = "https://github.com/SwissDataScienceCenter/renku"
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -2,13 +2,13 @@
 # Copyright 2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,14 +27,15 @@ out_graph_path = Path(
 validation_graph_path = Path("shaclgraph.ttl")
 
 
-@pytest.mark.skip('not yet implemented')
+@pytest.mark.skip("not yet implemented")
 def test_validate_output_is_linked_data():
     """Is output valid RDF?"""
     g = Graph()
     with open(out_graph_path) as output_graph:
         g.parse(output_graph, format="json-ld")
 
-@pytest.mark.skip('not yet implemented')
+
+@pytest.mark.skip("not yet implemented")
 def test_output_conforms_shapes():
     """Does graph conform SHACL shapes graph?"""
     g = Graph()


### PR DESCRIPTION
This PR is about adding pytest and formatting check as github actions.

- Python versions 3.8 up to 3.11 are considered
- Poetry is used to install the dependencies
- `black` is used to check formatting of the python files

Additional changes:
- corrects the formatting of the python code so that it passes black
- changes the repo url for this repo in the tests to the github url instead of providing the local path
- adds a testconfig to avoid an `ImportPathMismatchError` raised by pytest, see https://github.com/pytest-dev/pytest/issues/10119