### PR TITLE
Add action to publish

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -1,0 +1,16 @@
+name: Publish on Pypi
+
+on:
+  release:
+    types: [published]
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v1.16
+        with:
+          pypi_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -1,4 +1,4 @@
-name: Python Poetry Build
+name: Python Poetry Test
 
 on: [push]
 

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -1,0 +1,16 @@
+name: Publish on Pypi Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v1.16
+        with:
+          pypi_token: ${{ secrets.PYPI_TEST_API_TOKEN }}
+          repository_name: "testpypi"
+          repository_url: "https://test.pypi.org/legacy/"

--- a/README.md
+++ b/README.md
@@ -54,3 +54,11 @@ Or [poetry](https://python-poetry.org/), to work in an isolated virtual environm
 git clone https://github.com/SDSC-ORD/gimie && cd gimie
 poetry install
 ```
+
+## Releases and Publishing on Pypi
+
+Releases are done via github release
+
+- a release will trigger a github workflow to publish the package on Pypi
+- Make sure to update to a new version in `pyproject.toml` before making the release
+- It is possible to test the publishing on Pypi.test by running a manual workflow: go to github actions and run the Workflow: 'Publish on Pypi Test'

--- a/gimie/__init__.py
+++ b/gimie/__init__.py
@@ -16,7 +16,9 @@
 # limitations under the License.
 import logging
 
-__version__ = "0.1.0"
+import importlib.metadata as importlib_metadata
+
+__version__ = importlib_metadata.version(__name__)
 
 logger = logging.getLogger()
 logger.setLevel(logging.WARNING)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 # Dependency management
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 extruct = "^0.14.0"
 PyDriller = "^2.3"
 pyshacl = "^0.20.0"


### PR DESCRIPTION
This PR adds 2 new github workflows: 

- one workflow to publish the package on Pypi: it is triggered by github releases
- one workflow that is manually triggered to publish on test-Pypi.

Besides these changes:
- the version is now derived automatically in the `__init__.py` file, so that it only needs to be set in the `pyproject.toml` file
- the readme got a section on how to do a release.