### PR TITLE
feature: add github token to allow for more github api calls

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,3 @@
 # create your personal github token and add it here
 # see [here](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-GITHUB_TOKEN=
+ACCESS_TOKEN=

--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,3 @@
+# create your personal github token and add it here
+# see [here](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+GITHUB_TOKEN=

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -30,4 +30,6 @@ jobs:
         run: poetry run black . --check
 
       - name: Test with pytest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: poetry run pytest

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Test with pytest
         env:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          ACCESS_TOKEN: ${{ github.token }}
         run: poetry run pytest

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Test with pytest
         env:
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: poetry run pytest

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Test with pytest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: poetry run pytest

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Test with pytest
         env:
-          ACCESS_TOKEN: ${{ github.token }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: poetry run pytest

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Test with pytest
         env:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: poetry run pytest

--- a/README.md
+++ b/README.md
@@ -26,6 +26,36 @@ pip install git+https://github.com/SDSC-ORD/gimie.git#egg=gimie
 
 ## Usage
 
+### Set your github credentials
+
+In order to avoid rate limits with the github api, you need to provide your github
+username and a github token: see 
+[here ](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+on how to generate a github token.
+
+There are 2 options for setting up your github token in your local environment:
+
+**Option 1:**
+
+```
+cp .env.dist .env
+```
+
+And then edit the `.env` file and put your github token in.
+
+**Option 2:**
+
+Add your github token in your terminal:
+
+```bash
+export GITHUB_TOKEN=
+```
+
+After the github token has been added, you can run the command without running into an github api limit.
+Otherwise you can still run the command, but might hit that limit after running the command several times.
+
+### Run the command
+
 As a command line tool:
 ```shell
 gimie data https://github.com/numpy/numpy

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ And then edit the `.env` file and put your github token in.
 Add your github token in your terminal:
 
 ```bash
-export GITHUB_TOKEN=
+export ACCESS_TOKEN=
 ```
 
 After the github token has been added, you can run the command without running into an github api limit.

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -73,13 +73,12 @@ class GithubExtractor(Extractor):
         self.date_modified = datetime.fromisoformat(data["updated_at"][:-1])
         self.license = data["license"]["url"]
 
-    @classmethod
-    def _set_auth(cls) -> Any:
+    def _set_auth(self) -> Any:
         try:
-            if not cls.github_token:
-                cls.github_token = os.environ.get("ACCESS_TOKEN")
-                assert cls.github_token
-            headers = {"Authorization": f"token {cls.github_token}"}
+            if not self.github_token:
+                self.github_token = os.environ.get("ACCESS_TOKEN")
+                assert self.github_token
+            headers = {"Authorization": f"token {self.github_token}"}
 
             login = requests.get(
                 "https://api.github.com/user", headers=headers
@@ -90,8 +89,7 @@ class GithubExtractor(Extractor):
         else:
             return headers
 
-    @classmethod
-    def _request(cls, query_path: str) -> Any:
+    def _request(self, query_path: str) -> Any:
         """Wrapper to query github api and return
         a dictionary of the json response.
 
@@ -102,7 +100,7 @@ class GithubExtractor(Extractor):
 
         """
         resp = requests.get(
-            f"{GH_API}/{query_path.lstrip('/')}", headers=cls._set_auth()
+            f"{GH_API}/{query_path.lstrip('/')}", headers=self._set_auth()
         )
         # If the query fails, explain why
         if resp.status_code != 200:

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -39,6 +39,7 @@ load_dotenv()
 @dataclass
 class GithubExtractor(Extractor):
     path: str
+    github_token: Optional[str] = None
     name: Optional[str] = None
     author: Optional[Union[Organization, Person]] = None
     contributors: Optional[List[Person]] = None
@@ -75,9 +76,10 @@ class GithubExtractor(Extractor):
     @classmethod
     def _set_auth(cls) -> Any:
         try:
-            github_token = os.environ.get("ACCESS_TOKEN")
-            assert github_token
-            headers = {"Authorization": f"token {github_token}"}
+            if not cls.github_token:
+                cls.github_token = os.environ.get("ACCESS_TOKEN")
+                assert cls.github_token
+            headers = {"Authorization": f"token {cls.github_token}"}
 
             login = requests.get(
                 "https://api.github.com/user", headers=headers

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -38,7 +38,7 @@ load_dotenv()
 
 def _set_auth():
     try:
-        github_token = os.environ.get("GITHUB_TOKEN")
+        github_token = os.environ.get("ACCESS_TOKEN")
         assert github_token
         headers = {"Authorization": f"token {github_token}"}
 

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -43,7 +43,7 @@ def _set_auth():
         headers = {"Authorization": f"token {github_token}"}
 
         login = requests.get("https://api.github.com/user", headers=headers)
-        assert login.json().get('login')
+        assert login.json().get("login")
     except AssertionError:
         return {}
     else:
@@ -100,7 +100,9 @@ class GithubExtractor(Extractor):
             The query, without the base path.
 
         """
-        resp = requests.get(f"{GH_API}/{query_path.lstrip('/')}", headers=GH_HEADERS)
+        resp = requests.get(
+            f"{GH_API}/{query_path.lstrip('/')}", headers=GH_HEADERS
+        )
         # If the query fails, explain why
         if resp.status_code != 200:
             raise ConnectionError(resp.json()["message"])

--- a/poetry.lock
+++ b/poetry.lock
@@ -736,6 +736,21 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "python-dotenv"
+version = "0.21.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-dotenv-0.21.1.tar.gz", hash = "sha256:1c93de8f636cde3ce377292818d0e440b6e45a82f215c3744979151fa8151c49"},
+    {file = "python_dotenv-0.21.1-py3-none-any.whl", hash = "sha256:41e12e0318bebc859fcc4d97d4db8d20ad21721a6aa5047dd59f090391cb549a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytz"
 version = "2022.7.1"
 description = "World timezone definitions, modern and historical"
@@ -917,7 +932,6 @@ category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "wcwidth-0.2.6-py2.py3-none-any.whl", hash = "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e"},
     {file = "wcwidth-0.2.6.tar.gz", hash = "sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0"},
 ]
 
@@ -936,4 +950,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "59ec9cc8268a3e79396fa69e9e1273cc5f0524f011f201f0fc900126bfdb0b47"
+content-hash = "73ba229e133442ad1090b042438f0280c6253cbee190a6df9594d6f68900c426"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pyshacl = "^0.20.0"
 typer = "^0.7.0"
 calamus = "^0.4.1"
 requests = "^2.28.2"
+python-dotenv = "^0.21.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"


### PR DESCRIPTION
This PR adds a authorization to the requests going to the github api:

An Access Token is provided in the following ways:

- in the test workflow it is provided as a secret on the repo
- locally it can be provided in a `.env` file or as an environment variable in the shell

I tried to just use the GITHUB_TOKEN that should exist for all workflows, but for some reason that failed, not sure why. 