### PR TITLE
Update SHA for all actions with version in comments

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,12 +23,12 @@ jobs:
 
         # https://github.com/docker/setup-qemu-action
         - name: Set up QEMU
-          uses: docker/setup-qemu-action@v1
+          uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
 
         # https://github.com/docker/setup-buildx-action
         - name: Set up Docker Buildx
           id: buildx
-          uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98
+          uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # v2.4.0
 
         - name: Get current release version
           id: release-version
@@ -38,7 +38,7 @@ jobs:
             echo "version_build=${version}_"$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_OUTPUT
 
         - name: Log in to the Container registry
-          uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+          uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
           with:
             registry: ${{ env.REGISTRY }}
             username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
 
         - name: Extract metadata (tags, labels) for Docker
           id: meta
-          uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+          uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 #v4.3.0
           with:
             images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             tags: |
@@ -55,7 +55,7 @@ jobs:
               type=raw,value=${{ steps.release-version.outputs.version }},enable=${{ github.event_name == 'release' }}
 
         - name: Build and push Docker image
-          uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+          uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
           with:
             context: .
             platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Github made a major change in actions in October 2022 that deprecated some commands for Actions and will cause them to fail automatically from April 2023 if not updated. Currently `gimie` is using some old actions (Docker login, Docker extract metadata  and Docker Build and Push) that trigger the following warnings:
```bash
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Because of this I updated the SHA from the old actions but also the ones not triggering warnings. I added as comments the release versions to make it easier to understand the SHA source.