### PR TITLE
GitLab edge cases

### DIFF
--- a/gimie/sources/common/queries.py
+++ b/gimie/sources/common/queries.py
@@ -1,10 +1,10 @@
 import requests
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 
 
 def send_rest_query(
     api: str, query: str, headers: Dict[str, str]
-) -> Dict[str, Any]:
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """Generic function to send a query to the GitHub/GitLab rest API."""
     resp = requests.get(
         url=f"{api}/{query}",
@@ -32,22 +32,3 @@ def send_graphql_query(
     if resp.status_code != 200:
         raise ConnectionError(resp.json()["message"])
     return resp.json()
-
-
-def query_graphql(
-    api: str, repo_query: str, data: dict, headers: Dict[str, str]
-) -> Dict[str, Any]:
-    """Queries the GitHub GraphQL API to extract metadata about
-    target repository.
-
-    Parameters
-    ----------
-    api:
-        URL for GraphQL API
-    repo_query:
-        query defining what information should be retrieved from the GraphQL API.
-    data:
-        parameters of the query
-    """
-    repo = send_graphql_query(api, repo_query, data=data, headers=headers)
-    return repo

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -40,7 +40,6 @@ from gimie.graph.namespaces import SDO
 from gimie.sources.common.license import get_spdx_url
 from gimie.sources.common.queries import (
     send_rest_query,
-    query_graphql,
     send_graphql_query,
 )
 
@@ -212,7 +211,9 @@ class GithubExtractor(Extractor):
             }
         }
         """
-        response = query_graphql(GH_API, repo_query, data, self._set_auth())
+        response = send_graphql_query(
+            GH_API, repo_query, data, self._set_auth()
+        )
         if "errors" in response:
             raise ValueError(response["errors"])
 

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -241,15 +241,12 @@ class GitlabExtractor(Extractor):
 
     def _get_organization(self, node: Dict[str, Any]) -> Organization:
         """Extract details from a GraphQL organization node."""
-        try:
-            return Organization(
-                _id=node["webUrl"],
-                name=node["name"],
-                description=node.get("description"),
-                logo=node.get("avatarUrl"),
-            )
-        except KeyError:
-            breakpoint()
+        return Organization(
+            _id=node["webUrl"],
+            name=node["name"],
+            description=node.get("description"),
+            logo=node.get("avatarUrl"),
+        )
 
     def _get_user(self, node: Dict[str, Any]) -> Person:
         """Extract details from a GraphQL user node."""

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -110,7 +110,7 @@ class GitlabExtractor(Extractor):
             )
         ]
 
-        if len(data["releases"]["edges"]) > 0:
+        if data["releases"] and (len(data["releases"]["edges"]) > 0):
             # go into releases and take the name from the first node (most recent)
             self.version = data["releases"]["edges"][0]["node"]["name"]
             self.download_url = f"{self.path}/-/archive/{self.version}/{self.name.split('/')[-1]}-{self.version}.tar.gz"

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -6,6 +6,7 @@ TEST_REPOS = [
     "https://gitlab.com/openrgb-pvazny/OpenRGB",  # No user owner so group owner, no releases
     "https://gitlab.com/gitlab-org/gitlab-runner",  # No user owner so group owner, has releases
     "https://gitlab.com/commonground/haven/haven",  # Nested groups
+    "https://gitlab.com/edouardklein/falsisign",  # owned by user
 ]
 
 


### PR DESCRIPTION
The current GitLab extractor failed in repositories owned by a user, or with no release available.
This PR does the following:
* Add test case for user-owned repo without releases
* Fix breaking edge cases
* Split the `extract()` method into smaller attribute-based methods (`_safe_extract_{contributors,author,group}()`)
  + This keeps the logic out of extract to keep it readable and easy to maintain.

The GitLab GraphQL API returns an empty `projectMembers` for user-owned repository. This appears to be a bug, as this only happens with a personal access token and not their GraphiQL explorer tool. The `_safe_extract_author()` method will fallback to the REST API when `projectMembers` is empty.