### PR TITLE
Interface rework

### DIFF
--- a/gimie/cli.py
+++ b/gimie/cli.py
@@ -56,6 +56,11 @@ def data(
         show_choices=True,
         help="Output serialization format for the RDF graph.",
     ),
+    base_url: Optional[str] = typer.Option(
+        None,
+        "--base-url",
+        help="Specify the base URL of the git provider. Inferred by default.",
+    ),
     version: Optional[bool] = typer.Option(
         None,
         "--version",
@@ -66,7 +71,7 @@ def data(
     """Extract linked metadata from a Git repository at the target URL.
 
     The output is sent to stdout, and turtle is used as the default serialization format."""
-    proj = Project(url)
+    proj = Project(url, base_url=base_url)
     print(proj.serialize(format=format))
 
 

--- a/gimie/sources/abstract.py
+++ b/gimie/sources/abstract.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 
 from rdflib import Graph
+from urllib.parse import urlparse
 
 
 class Extractor(ABC):
@@ -30,10 +31,15 @@ class Extractor(ABC):
     they are free to override the default serialize() and jsonld()
     """
 
-    def __init__(self, path: str, _id: Optional[str] = None):
-        self.path = path
-        if _id is not None:
-            self._id = _id
+    def __init__(
+        self,
+        url: str,
+        base_url: Optional[str] = None,
+        local_path: Optional[str] = None,
+    ):
+        self.url = url
+        self.base_url = base_url
+        self.local_path = local_path
 
     @abstractmethod
     def extract(self):
@@ -52,3 +58,23 @@ class Extractor(ABC):
     def jsonld(self) -> str:
         """Alias for jsonld serialization."""
         return self.serialize(format="json-ld")
+
+    @property
+    def _id(self) -> str:
+        """Unique identifier for the repository."""
+        return self.url
+
+    @property
+    def path(self) -> str:
+        """Path to the repository."""
+        if self.local_path is None:
+            return self.url
+        return self.local_path
+
+    @property
+    def base(self) -> str:
+        """Base URL of the remote."""
+        if self.base_url is None:
+            url = urlparse(self.url)
+            return f"{url.scheme}://{url.netloc}"
+        return self.base_url

--- a/gimie/sources/abstract.py
+++ b/gimie/sources/abstract.py
@@ -66,10 +66,10 @@ class Extractor(ABC):
 
     @property
     def path(self) -> str:
-        """Path to the repository."""
-        if self.local_path is None:
-            return self.url
-        return self.local_path
+        """Path to the repository without the base URL."""
+        if self.base_url is None:
+            return urlparse(self.url).path.strip("/")
+        return self.url.removeprefix(self.base_url).strip("/")
 
     @property
     def base(self) -> str:

--- a/gimie/sources/git.py
+++ b/gimie/sources/git.py
@@ -50,8 +50,10 @@ class GitExtractor(Extractor):
         The repository we are extracting metadata from.
     """
 
-    path: str
-    _id: Optional[str] = None
+    url: str
+    base_url: Optional[str] = None
+    local_path: Optional[str] = None
+
     author: Optional[Person] = None
     contributors: Optional[List[Person]] = None
     date_created: Optional[datetime] = None
@@ -59,9 +61,6 @@ class GitExtractor(Extractor):
 
     def extract(self):
         self.repository = pydriller.Repository(self.path)
-        if self._id is None:
-            head_commit_hash = git.Repo(self.path).head.commit.hexsha[:7]
-            self._id = generate_uri(head_commit_hash)
         # Assuming author is the first person to commit
         self.author = self._get_creator()
         self.contributors = self._get_contributors()

--- a/gimie/sources/git.py
+++ b/gimie/sources/git.py
@@ -39,8 +39,12 @@ class GitExtractor(Extractor):
 
     Parameters
     ----------
-    path: str
-        The path to the git repository.
+    url: str
+        The url of the git repository.
+    base_url: Optional[str]
+        The base url of the git remote.
+    local_path: Optional[str]
+        The local path where the cloned git repository is located.
 
     Attributes
     ----------
@@ -60,7 +64,9 @@ class GitExtractor(Extractor):
     date_modified: Optional[datetime] = None
 
     def extract(self):
-        self.repository = pydriller.Repository(self.path)
+        if self.local_path is None:
+            raise ValueError("Local path must be provided for extraction.")
+        self.repository = pydriller.Repository(self.local_path)
         # Assuming author is the first person to commit
         self.author = self._get_creator()
         self.contributors = self._get_contributors()

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -123,7 +123,6 @@ class GithubExtractor(Extractor):
 
     def extract(self):
         """Extract metadata from target GitHub repository."""
-        self.name = self.path
         data = self._fetch_repo_data()
         self.author = self._get_author(data["owner"])
         self.contributors = self._fetch_contributors()
@@ -145,7 +144,7 @@ class GithubExtractor(Extractor):
 
     def _fetch_repo_data(self) -> Dict[str, Any]:
         """Fetch repository metadata from GraphQL endpoint."""
-        owner, name = self.name.split("/")
+        owner, name = self.path.split("/")
         data = {"owner": owner, "name": name}
         repo_query = """
         query repo($owner: String!, $name: String!) {
@@ -289,7 +288,7 @@ class GithubExtractorSchema(JsonLDSchema):
     """This defines the schema used for json-ld serialization."""
 
     _id = fields.Id()
-    name = fields.String(SDO.name)
+    path = fields.String(SDO.name)
     author = fields.Nested(SDO.author, [PersonSchema, OrganizationSchema])
     contributors = fields.Nested(SDO.contributor, PersonSchema, many=True)
     prog_langs = fields.List(SDO.programmingLanguage, fields.String)

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -117,7 +117,7 @@ class GithubExtractor(Extractor):
 
     def extract(self):
         """Extract metadata from target GitHub repository."""
-        self.name = urlparse(self.url).path.strip("/")
+        self.name = self.path
         data = self._fetch_repo_data()
         self.author = self._get_author(data["owner"])
         self.contributors = self._fetch_contributors()

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -90,7 +90,12 @@ def query_contributors(
 @dataclass
 class GithubExtractor(Extractor):
     """Extractor for GitHub repositories. Uses the GitHub GraphQL API to
-    extract metadata into linked data."""
+    extract metadata into linked data.
+    url: str
+        The url of the git repository.
+    base_url: Optional[str]
+        The base url of the git remote.
+    """
 
     url: str
     base_url: Optional[str] = None

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from dateutil.parser import isoparse
 import os
 import requests
 from typing import Any, Dict, List, Optional, Set, Union
@@ -127,8 +128,8 @@ class GithubExtractor(Extractor):
         self.author = self._get_author(data["owner"])
         self.contributors = self._fetch_contributors()
         self.description = data["description"]
-        self.date_created = datetime.fromisoformat(data["createdAt"][:-1])
-        self.date_modified = datetime.fromisoformat(data["updatedAt"][:-1])
+        self.date_created = isoparse(data["createdAt"][:-1])
+        self.date_modified = isoparse(data["updatedAt"][:-1])
         # If license is available, convert to standard SPDX URL
         if data["licenseInfo"] is not None:
             self.license = get_spdx_url(data["licenseInfo"]["spdxId"])

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -134,7 +134,7 @@ class GithubExtractor(Extractor):
         if last_release is not None:
             self.version = last_release["name"]
             self.download_url = (
-                f"{self.path}/archive/refs/tags/{self.version}.tar.gz"
+                f"{self.url}/archive/refs/tags/{self.version}.tar.gz"
             )
 
     def _fetch_repo_data(self) -> Dict[str, Any]:
@@ -221,7 +221,7 @@ class GithubExtractor(Extractor):
         NOTE: This is a workaround for the lack of a contributors field in the GraphQL API."""
         headers = self._set_auth()
         contributors = []
-        resp = query_contributors(self.path, headers)
+        resp = query_contributors(self.url, headers)
         for user in resp:
             contributors.append(self._get_user(user))
         return list(contributors)

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -84,7 +84,7 @@ class GitlabExtractor(Extractor):
         if data["releases"] and (len(data["releases"]["edges"]) > 0):
             # go into releases and take the name from the first node (most recent)
             self.version = data["releases"]["edges"][0]["node"]["name"]
-            self.download_url = f"{self.path}/-/archive/{self.version}/{self.name.split('/')[-1]}-{self.version}.tar.gz"
+            self.download_url = f"{self.url}/-/archive/{self.version}/{self.name.split('/')[-1]}-{self.version}.tar.gz"
 
         # for the license, we need to query the rest API
         # the code below does not work, returns - if you have permission- the GitLab specific licence

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import os
 import requests
 from datetime import datetime
+from dateutil.parser import isoparse
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
@@ -75,10 +76,8 @@ class GitlabExtractor(Extractor):
         self.source_organization = self._safe_extract_group(data)
         self.description = data["description"]
         self.prog_langs = [lang["name"] for lang in data["languages"]]
-        self.date_created = datetime.fromisoformat(data["createdAt"][:-1])
-        self.date_modified = datetime.fromisoformat(
-            data["lastActivityAt"][:-1]
-        )
+        self.date_created = isoparse(data["createdAt"][:-1])
+        self.date_modified = isoparse(data["lastActivityAt"][:-1])
         self.keywords = data["topics"]
 
         # Get contributors as the project members that are not owners and those that have written merge requests

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -27,7 +27,13 @@ load_dotenv()
 @dataclass
 class GitlabExtractor(Extractor):
     """Extractor for Gitlab repositories. Uses the Gitlab GraphQL API to
-    extract metadata into linked data."""
+    extract metadata into linked data.
+    url: str
+        The url of the git repository.
+    base_url: Optional[str]
+        The base url of the git remote.
+
+    """
 
     url: str
     base_url: Optional[str] = None

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -57,7 +57,7 @@ class GitlabExtractor(Extractor):
 
     def extract(self):
         """Extract metadata from target Gitlab repository."""
-        self.name = urlparse(self.url).path.strip("/")
+        self.name = self.path
 
         # fetch metadata
         data = self._fetch_repo_data(self.name)

--- a/poetry.lock
+++ b/poetry.lock
@@ -347,24 +347,24 @@ files = [
 
 [[package]]
 name = "docutils"
-version = "0.18.1"
+version = "0.19"
 description = "Docutils -- Python Documentation Utilities"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.7"
 files = [
-    {file = "docutils-0.18.1-py2.py3-none-any.whl", hash = "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c"},
-    {file = "docutils-0.18.1.tar.gz", hash = "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"},
+    {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
+    {file = "docutils-0.19.tar.gz", hash = "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6"},
 ]
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.1"
+version = "1.1.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
-    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
+    {file = "exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
+    {file = "exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
 ]
 
 [package.extras]
@@ -372,18 +372,18 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.12.0"
+version = "3.12.2"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "filelock-3.12.0-py3-none-any.whl", hash = "sha256:ad98852315c2ab702aeb628412cbf7e95b7ce8c3bf9565670b4eaecf1db370a9"},
-    {file = "filelock-3.12.0.tar.gz", hash = "sha256:fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718"},
+    {file = "filelock-3.12.2-py3-none-any.whl", hash = "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"},
+    {file = "filelock-3.12.2.tar.gz", hash = "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2023.5.20)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "frozendict"
@@ -528,13 +528,13 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.6.0"
+version = "6.7.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_metadata-6.6.0-py3-none-any.whl", hash = "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed"},
-    {file = "importlib_metadata-6.6.0.tar.gz", hash = "sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705"},
+    {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
+    {file = "importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4"},
 ]
 
 [package.dependencies]
@@ -543,7 +543,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
 name = "iniconfig"
@@ -957,28 +957,28 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.5.1"
+version = "3.8.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
-    {file = "platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
+    {file = "platformdirs-3.8.0-py3-none-any.whl", hash = "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"},
+    {file = "platformdirs-3.8.0.tar.gz", hash = "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
-version = "1.0.0"
+version = "1.2.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
-    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
+    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
 
 [package.extras]
@@ -987,13 +987,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "3.3.2"
+version = "3.3.3"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pre_commit-3.3.2-py2.py3-none-any.whl", hash = "sha256:8056bc52181efadf4aac792b1f4f255dfd2fb5a350ded7335d251a68561e8cb6"},
-    {file = "pre_commit-3.3.2.tar.gz", hash = "sha256:66e37bec2d882de1f17f88075047ef8962581f83c234ac08da21a0c58953d1f0"},
+    {file = "pre_commit-3.3.3-py2.py3-none-any.whl", hash = "sha256:10badb65d6a38caff29703362271d7dca483d01da88f9d7e05d0b97171c136cb"},
+    {file = "pre_commit-3.3.3.tar.gz", hash = "sha256:a2256f489cd913d575c145132ae196fe335da32d91a8294b7afe6622335dd023"},
 ]
 
 [package.dependencies]
@@ -1073,13 +1073,13 @@ requests = ["requests"]
 
 [[package]]
 name = "pyparsing"
-version = "3.0.9"
+version = "3.1.0"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 optional = false
 python-versions = ">=3.6.8"
 files = [
-    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
-    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+    {file = "pyparsing-3.1.0-py3-none-any.whl", hash = "sha256:d554a96d1a7d3ddaf7183104485bc19fd80543ad6ac5bdb6426719d766fb06c1"},
+    {file = "pyparsing-3.1.0.tar.gz", hash = "sha256:edb662d6fe322d6e990b1594b5feaeadf806803359e3d4d42f11e295e588f0ea"},
 ]
 
 [package.extras]
@@ -1112,13 +1112,13 @@ jsonld = ["rdflib-jsonld (>=0.4.0,<0.6)"]
 
 [[package]]
 name = "pytest"
-version = "7.3.1"
+version = "7.4.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
-    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
+    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
 ]
 
 [package.dependencies]
@@ -1130,10 +1130,9 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-
 name = "pytest-cov"
 version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
@@ -1150,6 +1149,20 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
@@ -1269,13 +1282,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "setuptools"
-version = "67.8.0"
+version = "68.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
-    {file = "setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
 ]
 
 [package.extras]
@@ -1568,13 +1581,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.6.3"
+version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.6.3-py3-none-any.whl", hash = "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26"},
-    {file = "typing_extensions-4.6.3.tar.gz", hash = "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"},
+    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
+    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]
 
 [[package]]
@@ -1596,23 +1609,23 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.23.0"
+version = "20.23.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.23.0-py3-none-any.whl", hash = "sha256:6abec7670e5802a528357fdc75b26b9f57d5d92f29c5462ba0fbe45feacc685e"},
-    {file = "virtualenv-20.23.0.tar.gz", hash = "sha256:a85caa554ced0c0afbd0d638e7e2d7b5f92d23478d05d17a76daeac8f279f924"},
+    {file = "virtualenv-20.23.1-py3-none-any.whl", hash = "sha256:34da10f14fea9be20e0fd7f04aba9732f84e593dac291b757ce42e3368a39419"},
+    {file = "virtualenv-20.23.1.tar.gz", hash = "sha256:8ff19a38c1021c742148edc4f81cb43d7f8c6816d2ede2ab72af5b84c749ade1"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.6,<1"
-filelock = ">=3.11,<4"
-platformdirs = ">=3.2,<4"
+filelock = ">=3.12,<4"
+platformdirs = ">=3.5.1,<4"
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
-test = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.7.1)", "time-machine (>=2.9)"]
+docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezer (>=0.4.6)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.8)", "time-machine (>=2.9)"]
 
 [[package]]
 name = "wcwidth"
@@ -1654,4 +1667,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "91d8a15b35c1490aa9d3de6b5359f1361a7860ea6c4e02cc1ac4776ebc61270c"
+content-hash = "23c3da54169e63f19cf10f0d49d16ca2ff74441ca791d60bbcd036dae93ecb06"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1039,6 +1039,20 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "0.21.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1541,4 +1555,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "40b97ec9d5dcc870ac7df12be12c609473f6f1c1c2bb2ab79e5935d458dc7ef1"
+content-hash = "151394a9a9d9869da7e07b2f9151f2a982eaa923ef0ac1ba7cd5ad1e29a231cb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ requests = "^2.28.2"
 python-dotenv = "^0.21.1"
 pre-commit = "^3.0.0"
 importlib = "^1.0.4"
+python-dateutil = "^2.8.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -8,14 +8,16 @@ import pytest
 from gimie.graph.namespaces import GIMIE
 
 LOCAL_REPOSITORY = os.getcwd()
-RENKU_REPOSITORY = "https://github.com/SwissDataScienceCenter/renku"
+RENKU_GITHUB = "https://github.com/SwissDataScienceCenter/renku"
 UNSUPPORTED_PROV = "https://codeberg.org/dnkl/foot"
 
 
 @pytest.fixture
 def local_meta():
     """Return metadata for a local repository."""
-    meta = GitExtractor(LOCAL_REPOSITORY)
+    meta = GitExtractor(
+        "https://github.com/SDSC-ORD/gimie", local_path=LOCAL_REPOSITORY
+    )
     meta.extract()
     return meta
 
@@ -31,7 +33,6 @@ def test_git_authors(local_meta):
     ]
     assert all([n in contribs for n in names])
     assert local_meta.author.name == "Cyril Matthey-Doret"
-    assert local_meta._id.startswith(GIMIE), "ID should be a Gimie URI"
 
 
 def test_git_creation_date(local_meta):
@@ -44,7 +45,9 @@ def test_git_creation_date(local_meta):
 
 
 def test_set_uri():
-    meta = GitExtractor(LOCAL_REPOSITORY, _id="https://example.com/test")
+    meta = GitExtractor(
+        "https://example.com/test", local_path=LOCAL_REPOSITORY
+    )
     meta.extract()
     assert meta._id == "https://example.com/test"
 
@@ -52,7 +55,7 @@ def test_set_uri():
 def test_clone_extract_github():
     """Clone Git repository by setting git extractor
     explicitely and extract metadata locally."""
-    meta = Project(RENKU_REPOSITORY, sources="git")
+    meta = Project(RENKU_GITHUB, sources="git")
 
 
 def test_clone_unsupported():


### PR DESCRIPTION
This PR reworks the `Extractor` interface and adds support for private Gitlab instances.

Before:
`Extractor(path: str)`
Now:
`Extractor(url: str, local_path: Optional[str], base_url: Optional[str])`

The CLI also allows to specify the base URL explicitely with `gimie data --base-url [...] ...`

This adds support for repositories from private gitlab instances, including those where the base url uses the path (e.g. https://hostname/gitlab).

Example use:

`gimie data https://example.gitlab.org/group/subgroup/repo`
`gimie data --base-url https://example.org/gitlab https://example.org/gitlab/group/repo`

```python
Project('https://example.gitlab.org/group/subgroup/repo')
```

```python
Project('https://example.org/gitlab/group/repo', base_url='https://example.org/gitlab')