### PR TITLE
fix: incorrect mapping for schema:codeRepository

### DIFF
--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -297,7 +297,7 @@ class GithubExtractorSchema(JsonLDSchema):
     date_created = fields.Date(SDO.dateCreated)
     date_modified = fields.Date(SDO.dateModified)
     license = fields.IRI(SDO.license)
-    path = fields.IRI(SDO.CodeRepository)
+    url = fields.IRI(SDO.codeRepository)
     keywords = fields.List(SDO.keywords, fields.String)
     version = fields.String(SDO.version)
 

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -300,7 +300,7 @@ class GitlabExtractorSchema(JsonLDSchema):
     date_created = fields.Date(SDO.dateCreated)
     date_modified = fields.Date(SDO.dateModified)
     # license = IRI(SDO.license)
-    path = fields.IRI(SDO.CodeRepository)
+    url = fields.IRI(SDO.codeRepository)
     keywords = fields.List(SDO.keywords, fields.String)
     version = fields.String(SDO.version)
 


### PR DESCRIPTION
This PR addresses 2 issues with `schema:codeRepository`:
* was mapped to `self.path` instead of `self.url`
* Incorrect capitalization for a property `CodeRepository` -> `codeRepository`