### PR TITLE
fix: NOASSERTION should not return triples.

### DIFF
--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -131,7 +131,8 @@ class GithubExtractor(Extractor):
         self.date_modified = isoparse(data["updatedAt"][:-1])
         # If license is available, convert to standard SPDX URL
         if data["licenseInfo"] is not None:
-            self.license = get_spdx_url(data["licenseInfo"]["spdxId"])
+            if "NOASSERTION" not in str(data["licenseInfo"]):
+                self.license = get_spdx_url(data["licenseInfo"]["spdxId"])
         if data["primaryLanguage"] is not None:
             self.prog_langs = [data["primaryLanguage"]["name"]]
         self.keywords = self._get_keywords(*data["repositoryTopics"]["nodes"])


### PR DESCRIPTION
Because the Github API is a bit picky with licenses, it sometimes return "NOASSERTION" as the value of a license. This happens when it has found "something" licenselike, but cannot match it exactly to a spdx license. In that case, we don't want it to return a triple 
:someObject schema:license <spdx.org/NOASSERTION> since that doesn't actually exist. Instead, it should not return any triple for license.

I solved it a bit brutely with a string check for the licenseInfo, but it's simple, as long as spdx does not suddenly introduce a license called "NOASSERTION".