### PR TITLE
feature: license matcher for git extractor

### DIFF
--- a/gimie/io.py
+++ b/gimie/io.py
@@ -11,6 +11,9 @@ class Resource:
     """Abstract class for buffered read-only access to local or remote resources via
     a file-like interface."""
 
+    name: str
+    path: Union[str, os.PathLike]
+
     def open(self) -> io.BufferedReader:
         raise NotImplementedError
 

--- a/gimie/io.py
+++ b/gimie/io.py
@@ -12,7 +12,6 @@ class Resource:
     a file-like interface."""
 
     name: str
-    path: Union[str, os.PathLike]
 
     def open(self) -> io.BufferedReader:
         raise NotImplementedError
@@ -34,7 +33,7 @@ class LocalResource(Resource):
     """
 
     def __init__(self, path: Union[str, os.PathLike]):
-        self.path = Path(path)
+        self.path: Path = Path(path)
 
     def open(self, mode="r") -> io.BufferedReader:
         return io.BufferedReader(io.FileIO(self.path, mode))

--- a/gimie/sources/abstract.py
+++ b/gimie/sources/abstract.py
@@ -87,10 +87,9 @@ class Extractor(ABC):
 
     def _get_licenses(self) -> list[str]:
         """Extract a SPDX License URL from a GitHub Repository"""
-        license_files_iterator = filter(
+        license_files = filter(
             lambda p: is_license_path(p.name), self.list_files()
         )
-        license_files = list(license_files_iterator)
         license_urls = []
         for file in license_files:
             license_url = _get_license_url(file)

--- a/gimie/sources/abstract.py
+++ b/gimie/sources/abstract.py
@@ -21,7 +21,7 @@ from typing import List, Optional
 
 from rdflib import Graph
 from urllib.parse import urlparse
-from gimie.sources.common.license import _get_license_url, is_license_path
+from gimie.sources.common.license import get_license_url, is_license_path
 from gimie.io import Resource
 
 
@@ -85,14 +85,14 @@ class Extractor(ABC):
             return f"{url.scheme}://{url.netloc}"
         return self.base_url
 
-    def _get_licenses(self) -> list[str]:
+    def _get_licenses(self) -> List[str]:
         """Extract a SPDX License URL from a GitHub Repository"""
         license_files = filter(
             lambda p: is_license_path(p.name), self.list_files()
         )
         license_urls = []
         for file in license_files:
-            license_url = _get_license_url(file)
+            license_url = get_license_url(file)
             if license_url:
                 license_urls.append(license_url)
         return license_urls

--- a/gimie/sources/abstract.py
+++ b/gimie/sources/abstract.py
@@ -86,7 +86,7 @@ class Extractor(ABC):
         return self.base_url
 
     def _get_licenses(self) -> List[str]:
-        """Extract a SPDX License URL from a GitHub Repository"""
+        """Extracts SPDX License URLs from the repository."""
         license_files = filter(
             lambda p: is_license_path(p.name), self.list_files()
         )

--- a/gimie/sources/abstract.py
+++ b/gimie/sources/abstract.py
@@ -21,6 +21,7 @@ from typing import List, Optional
 
 from rdflib import Graph
 from urllib.parse import urlparse
+from gimie.sources.common.license import _get_license_url, is_license_path
 from gimie.io import Resource
 
 
@@ -83,3 +84,16 @@ class Extractor(ABC):
             url = urlparse(self.url)
             return f"{url.scheme}://{url.netloc}"
         return self.base_url
+
+    def _get_licenses(self) -> list[str]:
+        """Extract a SPDX License URL from a GitHub Repository"""
+        license_files_iterator = filter(
+            lambda p: is_license_path(p.name), self.list_files()
+        )
+        license_files = list(license_files_iterator)
+        license_urls = []
+        for file in license_files:
+            license_url = _get_license_url(file)
+            if license_url:
+                license_urls.append(license_url)
+        return license_urls

--- a/gimie/sources/common/license.py
+++ b/gimie/sources/common/license.py
@@ -6,6 +6,8 @@ from typing import Iterable, List, Optional
 from gimie.io import Resource
 import tempfile
 
+SPDX_IDS = list(LICENSES.keys())
+
 
 def get_license_url(license_file: Resource) -> Optional[str]:
     """Takes the path of a text file containing a license text, and matches this
@@ -19,7 +21,9 @@ def get_license_url(license_file: Resource) -> Optional[str]:
         "license_detections"
     ]
     license_id = get_license_with_highest_coverage(license_detections)  # type: ignore
-    spdx_license_id = get_spdx_license_id(LICENSES.keys(), license_id)
+    if license_id is None:
+        return None
+    spdx_license_id = get_spdx_license_id(license_id)
     os.unlink(temp_file.name)
     if spdx_license_id:
         return f"https://spdx.org/licenses/{str(spdx_license_id)}.html"
@@ -28,25 +32,23 @@ def get_license_url(license_file: Resource) -> Optional[str]:
 
 
 def get_spdx_license_id(
-    ref_licenses: Iterable[str], license_id: Optional[str]
+    license_id: str,
+    spdx_ids: Iterable[str] = SPDX_IDS,
 ) -> Optional[str]:
     """Given a scancode API license ID also known as a license detection, returns the correctly capitalized
     spdx id corresponding to it.
 
     Parameters
     ----------
-    ref_licenses: Iterable[str]
-        An iterable of (reference) SPDX license ids.
-    license_id: Optional[str]
+    license_id:
         A license id to match with SPDX licenses.
+    spdx_ids:
+        An iterable of (reference) SPDX license ids.
     """
 
-    lower_ref_licenses = {ref.lower(): ref for ref in ref_licenses}
+    lower_spdx_ids = {spdx.lower(): spdx for spdx in spdx_ids}
 
-    if license_id in lower_ref_licenses:
-        return lower_ref_licenses[license_id]
-
-    return None
+    return lower_spdx_ids.get(license_id.lower(), None)
 
 
 def is_license_path(filename: str) -> bool:

--- a/gimie/sources/common/license.py
+++ b/gimie/sources/common/license.py
@@ -10,9 +10,16 @@ SPDX_IDS = list(LICENSES.keys())
 
 
 def get_license_url(license_file: Resource) -> Optional[str]:
-    """Takes the path of a text file containing a license text, and matches this
+    """Takes a file-like resource containing a license text, and matches its content
     using the scancode API to get possible license matches. The best match is
-    then returned as a spdx license URL"""
+    then returned as a spdx license URL.
+
+    Examples
+    --------
+    >>> from gimie.io import LocalResource
+    >>> get_license_url(LocalResource('LICENSE'))
+    'https://spdx.org/licenses/Apache-2.0.html'
+    """
     temp_file = tempfile.NamedTemporaryFile(delete=False)
     temp_file.write(license_file.open().read())
     temp_file.close()
@@ -44,6 +51,13 @@ def get_spdx_license_id(
         A license id to match with SPDX licenses.
     spdx_ids:
         An iterable of (reference) SPDX license ids.
+
+    Examples
+    --------
+    >>> get_spdx_license_id('apache-2.0')
+    'Apache-2.0'
+    >>> get_spdx_license_id('gpl-3.0')
+    'GPL-3.0'
     """
 
     lower_spdx_ids = {spdx.lower(): spdx for spdx in spdx_ids}
@@ -52,7 +66,22 @@ def get_spdx_license_id(
 
 
 def is_license_path(filename: str) -> bool:
-    """Given an input filename, returns a boolean indicating whether the filename path looks like a license."""
+    """Given an input filename, returns a boolean indicating whether the filename path looks like a license.
+
+    Parameters
+    ----------
+    filename:
+        A filename to check.
+
+    Examples
+    --------
+    >>> is_license_path('LICENSE.txt')
+    True
+    >>> is_license_path('LICENSE-APACHE')
+    True
+    >>> is_license_path('README.md')
+    False
+    """
     if filename.startswith("."):
         return False
     pattern = r".*(license(s)?.*|lizenz|reus(e|ing).*|copy(ing)?.*)(\.(txt|md|rst))?$"
@@ -66,7 +95,20 @@ def get_license_with_highest_coverage(
 ) -> Optional[str]:
     """Filters a list of "license detections" (the output of scancode.api.get_licenses)
     to return the one with the highest match percentage.
-    This is used to select among multiple license matches from a single file."""
+    This is used to select among multiple license matches from a single file.
+
+    Parameters
+    ----------
+    license_detections:
+        A list of license detections, as returned by scancode.api.get_licenses.
+
+    Examples
+    --------
+    >>> from scancode.api import get_licenses
+    >>> license_detections = get_licenses('LICENSE')['license_detections']
+    >>> get_license_with_highest_coverage(license_detections)
+    'apache-2.0'
+    """
     highest_coverage = 0.0
     highest_license = None
 

--- a/gimie/sources/common/license.py
+++ b/gimie/sources/common/license.py
@@ -1,34 +1,42 @@
 import re
-from spdx_license_list import LICENSES
+from spdx_license_list import LICENSES, License
 from scancode.api import get_licenses
-from typing import List
+from typing import Iterable, List, Optional
 from gimie.io import Resource, iterable_to_stream, RemoteResource
 
 
-def _get_licenses(temp_file_path: str) -> str:
-    """Takes a file with a license text in it, and matches this using the scancode API to a license to get some possible
-    license matches. The highest match is then returned as a spdx license ID"""
+def _get_license_url(temp_file_path: str) -> str:
+    """Takes the path of a text file containing a license text, and matches this
+    using the scancode API to get possible license matches. The best match is
+    then returned as a spdx license URL"""
     license_detections = get_licenses(temp_file_path, include_text=True)[
         "license_detections"
     ]
-    license_id = get_license_with_highest_coverage(license_detections)
-    spdx_license_id = get_spdx_license_id(LICENSES, license_id)
+    license_id = get_license_with_highest_coverage(license_detections)  # type: ignore
+    spdx_license_id = get_spdx_license_id(LICENSES.keys(), license_id)
+    spdx_license_url = f"https://spdx.org/licenses/{str(spdx_license_id)}.html"
 
-    return spdx_license_id
+    return spdx_license_url
 
 
-def get_spdx_license_id(license_dict: dict, license_id: str) -> str:
-    """Given a scamcode API license ID also known as a license detection, returns the correctly capitalized
-    spdx id corresponding to it"""
-    if not license_id:
-        return None  # Return None if the dictionary is empty
+def get_spdx_license_id(
+    ref_licenses: Iterable[str], license_id: Optional[str]
+) -> Optional[str]:
+    """Given a scancode API license ID also known as a license detection, returns the correctly capitalized
+    spdx id corresponding to it.
 
-    for key, value in license_dict.items():
-        if license_id:
-            if key.lower() == license_id.lower():
-                return value.id
-        else:
-            return None
+    Parameters
+    ----------
+    ref_licenses: Iterable[str]
+        An iterable of (reference) SPDX license ids.
+    license_id: Optional[str]
+        A license id to match with SPDX licenses.
+    """
+
+    lower_ref_licenses = {ref.lower(): ref for ref in ref_licenses}
+
+    if license_id in lower_ref_licenses:
+        return lower_ref_licenses[license_id]
 
     return None
 
@@ -43,7 +51,9 @@ def is_license_path(filename: str) -> bool:
     return False
 
 
-def get_license_with_highest_coverage(license_detections: List[dict]) -> str:
+def get_license_with_highest_coverage(
+    license_detections: List[dict],
+) -> Optional[str]:
     """Filters a list of "license detections" (the output of scancode.api.get_licenses)
     to return the one with the highest match percentage.
     This is used to select among multiple license matches from a single file."""
@@ -54,12 +64,8 @@ def get_license_with_highest_coverage(license_detections: List[dict]) -> str:
 
         matches = detection["matches"] if "matches" in detection else []
         for match in matches:
-            match_coverage = match["score"] if "score" in match else 0
+            match_coverage = match.get("score", 0)
             if match_coverage > highest_coverage:
                 highest_coverage = match_coverage
-                highest_license = (
-                    match["license_expression"]
-                    if "license_expression" in match
-                    else None
-                )
+                highest_license = match.get("license_expression", None)
     return highest_license

--- a/gimie/sources/common/license.py
+++ b/gimie/sources/common/license.py
@@ -1,13 +1,13 @@
 import os
 import re
-from spdx_license_list import LICENSES, License
+from spdx_license_list import LICENSES
 from scancode.api import get_licenses
 from typing import Iterable, List, Optional
-from gimie.io import Resource, iterable_to_stream, RemoteResource
+from gimie.io import Resource
 import tempfile
 
 
-def _get_license_url(license_file: Resource) -> Optional[str]:
+def get_license_url(license_file: Resource) -> Optional[str]:
     """Takes the path of a text file containing a license text, and matches this
     using the scancode API to get possible license matches. The best match is
     then returned as a spdx license URL"""

--- a/gimie/sources/common/license.py
+++ b/gimie/sources/common/license.py
@@ -24,7 +24,7 @@ def get_license_url(license_file: Resource) -> Optional[str]:
     if license_id is None:
         return None
     spdx_license_id = get_spdx_license_id(license_id)
-    os.unlink(temp_file.name)
+    os.remove(temp_file.name)
     if spdx_license_id:
         return f"https://spdx.org/licenses/{str(spdx_license_id)}.html"
 

--- a/gimie/sources/git.py
+++ b/gimie/sources/git.py
@@ -82,10 +82,10 @@ class GitExtractor(Extractor):
         if self.local_path is None:
             return file_list
 
-        for p in Path(self.local_path).rglob("*"):
-            if (p.parts[0] == ".git") or not p.is_file():
+        for path in Path(self.local_path).rglob("*"):
+            if (path.parts[0] == ".git") or not path.is_file():
                 continue
-            file_list.append(LocalResource(p))
+            file_list.append(LocalResource(path))
 
         return file_list
 

--- a/gimie/sources/git.py
+++ b/gimie/sources/git.py
@@ -17,7 +17,7 @@
 """Extractor which uses a locally available (usually cloned) repository."""
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import List, Optional
 import uuid
 
 from calamus import fields
@@ -28,10 +28,6 @@ from rdflib import Graph
 
 from gimie.io import LocalResource
 from gimie.graph.namespaces import SDO
-from gimie.sources.common.license import (
-    _get_license_url,
-    is_license_path,
-)
 from gimie.models import Person, PersonSchema
 from gimie.sources.abstract import Extractor
 from pathlib import Path

--- a/gimie/sources/git.py
+++ b/gimie/sources/git.py
@@ -86,8 +86,8 @@ class GitExtractor(Extractor):
         if self.local_path is None:
             return file_list
 
-        for p in Path(self.local_path).rglob(""):
-            if ".git" in p.parts or not p.is_file():
+        for p in Path(self.local_path).rglob("*"):
+            if (p.parts[0] == ".git") or not p.is_file():
                 continue
             file_list.append(LocalResource(p))
 

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -40,11 +40,6 @@ from gimie.models import (
 from gimie.graph.namespaces import SDO
 
 from gimie.io import RemoteResource
-from gimie.sources.common.license import (
-    get_license_with_highest_coverage,
-    is_license_path,
-    _get_license_url,
-)
 from gimie.sources.common.queries import (
     send_rest_query,
     send_graphql_query,

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -43,7 +43,7 @@ from gimie.io import RemoteResource
 from gimie.sources.common.license import (
     get_license_with_highest_coverage,
     is_license_path,
-    _get_licenses,
+    _get_license_url,
 )
 from gimie.sources.common.queries import (
     send_rest_query,
@@ -328,16 +328,14 @@ class GithubExtractor(Extractor):
             lambda p: is_license_path(p.name), self.list_files()
         )
         license_files = list(license_files_iterator)
-        license_ids = []
+        license_urls = []
         for file in license_files:
             with tempfile.NamedTemporaryFile(delete=False) as temp_file:
                 temp_file.write(file.open().read())
-                license_id = _get_licenses(temp_file.name)
-                if license_id:
-                    license_ids.append(
-                        f"https://spdx.org/licenses/{str(license_id)}.html"
-                    )
-        return license_ids
+                license_url = _get_license_url(temp_file.name)
+                if license_url:
+                    license_urls.append(license_url)
+        return license_urls
 
 
 class GithubExtractorSchema(JsonLDSchema):

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -322,21 +322,6 @@ class GithubExtractor(Extractor):
             affiliations=orgs,
         )
 
-    def _get_licenses(self) -> list[str]:
-        """Extract a SPDX License URL from a GitHub Repository"""
-        license_files_iterator = filter(
-            lambda p: is_license_path(p.name), self.list_files()
-        )
-        license_files = list(license_files_iterator)
-        license_urls = []
-        for file in license_files:
-            with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-                temp_file.write(file.open().read())
-                license_url = _get_license_url(temp_file.name)
-                if license_url:
-                    license_urls.append(license_url)
-        return license_urls
-
 
 class GithubExtractorSchema(JsonLDSchema):
     """This defines the schema used for json-ld serialization."""

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -156,8 +156,8 @@ class GithubExtractor(Extractor):
             self.date_published = isoparse(
                 data["latestRelease"]["publishedAt"]
             )
-        if self._get_license() != "https://spdx.org/licenses/None.html":
-            self.license = self._get_license()
+
+        self.license = self._get_licenses()
         if data["primaryLanguage"] is not None:
             self.prog_langs = [data["primaryLanguage"]["name"]]
         self.keywords = self._get_keywords(*data["repositoryTopics"]["nodes"])
@@ -322,7 +322,7 @@ class GithubExtractor(Extractor):
             affiliations=orgs,
         )
 
-    def _get_license(self) -> list[str]:
+    def _get_licenses(self) -> list[str]:
         """Extract a SPDX License URL from a GitHub Repository"""
         license_files_iterator = filter(
             lambda p: is_license_path(p.name), self.list_files()

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -21,11 +21,6 @@ from gimie.models import (
     PersonSchema,
 )
 from gimie.sources.abstract import Extractor
-from gimie.sources.common.license import (
-    get_license_with_highest_coverage,
-    is_license_path,
-    _get_license_url,
-)
 from gimie.sources.common.queries import send_graphql_query, send_rest_query
 
 load_dotenv()
@@ -149,7 +144,7 @@ class GitlabExtractor(Extractor):
 
     def _safe_extract_contributors(
         self, repo: dict[str, Any]
-    ) -> list[Person] | None:
+    ) -> List[Person] | None:
         members = [
             user["node"]["user"]
             for user in repo["projectMembers"]["edges"]

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -286,21 +286,6 @@ class GitlabExtractor(Extractor):
             email=node.get("publicEmail"),
         )
 
-    def _get_licenses(self) -> list[str]:
-        """Extract a SPDX License URL from a GitLab Repository"""
-        license_files_iterator = filter(
-            lambda p: is_license_path(p.name), self.list_files()
-        )
-        license_files = list(license_files_iterator)
-        license_urls = []
-        for file in license_files:
-            with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-                temp_file.write(file.open().read())
-                license_url = _get_license_url(temp_file.name)
-                if license_urls:
-                    license_urls.append(license_url)
-        return license_urls
-
     def _user_from_rest(self, username: str) -> Person:
         """Given a username, use the REST API to retrieve the Person object."""
 

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -24,7 +24,7 @@ from gimie.sources.abstract import Extractor
 from gimie.sources.common.license import (
     get_license_with_highest_coverage,
     is_license_path,
-    _get_licenses,
+    _get_license_url,
 )
 from gimie.sources.common.queries import send_graphql_query, send_rest_query
 
@@ -286,22 +286,20 @@ class GitlabExtractor(Extractor):
             email=node.get("publicEmail"),
         )
 
-    def _get_license(self) -> list[str]:
+    def _get_licenses(self) -> list[str]:
         """Extract a SPDX License URL from a GitLab Repository"""
         license_files_iterator = filter(
             lambda p: is_license_path(p.name), self.list_files()
         )
         license_files = list(license_files_iterator)
-        license_ids = []
+        license_urls = []
         for file in license_files:
             with tempfile.NamedTemporaryFile(delete=False) as temp_file:
                 temp_file.write(file.open().read())
-                license_id = _get_licenses(temp_file.name)
-                if license_id:
-                    license_ids.append(
-                        f"https://spdx.org/licenses/{str(license_id)}.html"
-                    )
-        return license_ids
+                license_url = _get_license_url(temp_file.name)
+                if license_urls:
+                    license_urls.append(license_url)
+        return license_urls
 
     def _user_from_rest(self, username: str) -> Person:
         """Given a username, use the REST API to retrieve the Person object."""

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -101,7 +101,7 @@ class GitlabExtractor(Extractor):
             self.date_published = isoparse(
                 data["releases"]["edges"][0]["node"]["releasedAt"]
             )
-        self.license = self._get_license()
+        self.license = self._get_licenses()
         self.keywords = data["topics"]
 
         # Get contributors as the project members that are not owners and those that have written merge requests


### PR DESCRIPTION
This PR adds support for local license detection on the Git extractor. Thus enabling it for git providers other than github and gitlab.
It also simplifies the license matching code and moves some boilerplate common across extractors to the abstract class.