### PR TITLE
feat(github.py): Get "forked from" property of a repository

### DIFF
--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -360,6 +360,7 @@ class GithubExtractorSchema(JsonLDSchema):
     date_published = fields.Date(SDO.datePublished)
     license = fields.List(SDO.license, fields.IRI)
     url = fields.IRI(SDO.codeRepository)
+    # NOTE: parent_repository is not available for GitLab's GraphQL API in 2023. Add for GitLab when available
     parent_repository = fields.IRI(SDO.isBasedOnUrl)
     keywords = fields.List(SDO.keywords, fields.String)
     version = fields.String(SDO.version)

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -131,6 +131,7 @@ class GithubExtractor(Extractor):
         return g
 
     def list_files(self) -> List[RemoteResource]:
+        """takes the root repository folder and returns the list of files present"""
         file_list = []
         file_dict = self._repo_data["object"]["entries"]
         repo_url = self._repo_data["url"]

--- a/gimie/sources/github.py
+++ b/gimie/sources/github.py
@@ -118,6 +118,7 @@ class GithubExtractor(Extractor):
     date_created: Optional[datetime] = None
     date_modified: Optional[datetime] = None
     date_published: Optional[datetime] = None
+    parent_repository: Optional[str] = None
     keywords: Optional[List[str]] = None
     license: Optional[List[str]] = None
     software_version: Optional[str] = None
@@ -152,6 +153,8 @@ class GithubExtractor(Extractor):
         self.description = data["description"]
         self.date_created = isoparse(data["createdAt"][:-1])
         self.date_modified = isoparse(data["updatedAt"][:-1])
+        if data["parent"]:
+            self.parent_repository = data["parent"]["url"]
         if data["latestRelease"]:
             self.date_published = isoparse(
                 data["latestRelease"]["publishedAt"]
@@ -177,6 +180,7 @@ class GithubExtractor(Extractor):
         query repo($owner: String!, $name: String!) {
             repository(name: $name, owner: $owner) {
                 url
+                parent {url}
                 createdAt
                 description
                 latestRelease {
@@ -355,6 +359,7 @@ class GithubExtractorSchema(JsonLDSchema):
     date_published = fields.Date(SDO.datePublished)
     license = fields.List(SDO.license, fields.IRI)
     url = fields.IRI(SDO.codeRepository)
+    parent_repository = fields.IRI(SDO.isBasedOnUrl)
     keywords = fields.List(SDO.keywords, fields.String)
     version = fields.String(SDO.version)
 

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -70,6 +70,7 @@ class GitlabExtractor(Extractor):
         return g
 
     def list_files(self) -> List[RemoteResource]:
+        """takes the root repository folder and returns the list of files present"""
         file_list = []
         file_dict = self._repo_data["repository"]["tree"]["blobs"]["nodes"]
         defaultbranchref = self._repo_data["repository"]["rootRef"]
@@ -172,6 +173,7 @@ class GitlabExtractor(Extractor):
         query project_query($path: ID!) {
             project(fullPath: $path) {
                 name
+                forkDetails {hasConflicts}
                 id
                 description
                 createdAt
@@ -240,6 +242,7 @@ class GitlabExtractor(Extractor):
         response = send_graphql_query(
             self.graphql_endpoint, project_query, data, self._set_auth()
         )
+        print(response)
         if "errors" in response:
             raise ValueError(response["errors"])
 

--- a/gimie/sources/gitlab.py
+++ b/gimie/sources/gitlab.py
@@ -173,7 +173,6 @@ class GitlabExtractor(Extractor):
         query project_query($path: ID!) {
             project(fullPath: $path) {
                 name
-                forkDetails {hasConflicts}
                 id
                 description
                 createdAt
@@ -242,7 +241,6 @@ class GitlabExtractor(Extractor):
         response = send_graphql_query(
             self.graphql_endpoint, project_query, data, self._set_auth()
         )
-        print(response)
         if "errors" in response:
             raise ValueError(response["errors"])
 


### PR DESCRIPTION
Resolved as a triple schema:isBasedOn. (schema does not have is forked from or similar). Uses the GraphQL API for GitHub. Gitlab GraphQL endpoint does not have this functionality at the moment.