### PR TITLE
CI/CD fix and new trigger

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -14,12 +14,6 @@ LABEL org.opencontainers.image.version ${VERSION_BUILD}
 ##################################################
 FROM python as poetry
 
-# Install system library
-
-RUN apt-get -y update && \
-    apt-get -y install libgomp1 && \
-    rm -rf /var/lib/apt/lists/*
-
 # Install poetry
 ENV POETRY_HOME=/opt/poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
@@ -42,7 +36,7 @@ RUN poetry install --no-interaction --no-ansi -vvv
 ##################################################
 FROM python as runtime
 ENV PATH="/app/.venv/bin:$PATH"
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git libgomp1
 COPY --from=poetry /app /app
 COPY ".docker/entrypoint.sh" "/entrypoint.sh"
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,57 +14,77 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-    build-and-push-image:
-      runs-on: ubuntu-latest
-      permissions:
-        contents: read
-        packages: write
+  build-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-        # https://github.com/docker/setup-qemu-action
-        - name: Set up QEMU
-          uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
 
-        # https://github.com/docker/setup-buildx-action
-        - name: Set up Docker Buildx
-          id: buildx
-          uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # v2.4.0
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # v2.4.0
 
-        - name: Get current release version
-          id: release-version
-          run: |
-            version=$(grep -E '^version += +' pyproject.toml | sed -E 's/.*= +//' | sed "s/['\"]//g")
-            echo "version=${version}" >> $GITHUB_OUTPUT
-            echo "version_build=${version}_"$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_OUTPUT
+      - name: Get current release version
+        id: release-version
+        run: |
+          version=$(grep -E '^version += +' pyproject.toml | sed -E 's/.*= +//' | sed "s/['\"]//g")
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "version_build=${version}_"$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_OUTPUT
 
-        - name: Log in to the Container registry
-          uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
-          with:
-            registry: ${{ env.REGISTRY }}
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: .docker/Dockerfile
+          push: false
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.release-version.outputs.version_build }}
+          build-args: VERSION_BUILD=${{ steps.release-version.outputs.version_build }}
+          outputs: type=image,annotation-index.org.opencontainers.image.description=Extract linked metadata from repositories.
 
-        - name: Extract metadata (tags, labels) for Docker
-          id: meta
-          uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 #v4.3.0
-          with:
-            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            tags: |
-              type=raw,value=latest,enable=${{ github.event_name == 'push' }}
-              type=raw,value=${{ steps.release-version.outputs.version_build }},enable=${{ github.event_name == 'push' }}
-              type=raw,value=${{ steps.release-version.outputs.version }},enable=${{ github.event_name == 'release' }}
+  push-image:
+    needs: build-image
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
 
-        - name: Build and push Docker image
-          uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
-          with:
-            context: .
-            platforms: linux/amd64,linux/arm64
-            file: .docker/Dockerfile
-            push: true
-            tags: ${{ steps.meta.outputs.tags }}
-            labels: ${{ steps.meta.outputs.labels }}
-            build-args: VERSION_BUILD=${{ steps.release-version.outputs.version_build }}
-            outputs: type=image,annotation-index.org.opencontainers.image.description=Extract linked metadata from repositories.
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 #v4.3.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+            type=raw,value=${{ needs.build-image.outputs.version_build }},enable=${{ github.event_name == 'push' }}
+            type=raw,value=${{ needs.build-image.outputs.version }},enable=${{ github.event_name == 'release' }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: .docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION_BUILD=${{ needs.build-image.outputs.version_build }}
+          outputs: type=image,annotation-index.org.opencontainers.image.description=Extract linked metadata from repositories.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,9 @@ on:
     type: [published]
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - 'pyproject.toml'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
It seems that my previous fix was on the wrong layer in the Dockerfile. Now the `libgomp1` install is in the step before executing `gimie`. 
I also added a new trigger to the CI/CD file to prevent the system from breaking when new dependencies are added. To do so, I'm using [`paths`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths) and I'm targeting `pyproject.toml`. The new GH Action for Docker build will trigger on PRs ONLY when `pyproject.toml` has changed. I hope this makes sense.
Note that we can only test after merging for now 😢 