### PR TITLE
chore(actions): update and restructure actions

### DIFF
--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -11,6 +11,7 @@ jobs:
   title-format:
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/amannn/action-semantic-pull-request
       - uses: amannn/action-semantic-pull-request@v5.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths:
       - 'pyproject.toml'
+      - './docker/**'
+      - '.github/workflows/**'
 
 env:
   REGISTRY: ghcr.io
@@ -15,13 +17,15 @@ env:
 jobs:
   build-image:
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
     permissions:
       contents: read
       packages: write
 
     steps:
+      # https://github.com/actions/checkout
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: lowercase image name
         run: |
@@ -29,12 +33,12 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        uses: docker/setup-qemu-action@v3.0.0
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # v2.4.0
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Get current release version
         id: release-version
@@ -43,8 +47,9 @@ jobs:
           echo "version=${version}" >> $GITHUB_OUTPUT
           echo "version_build=${version}_"$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_OUTPUT
 
+      # https://github.com/docker/build-push-action
       - name: Build Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
+        uses: docker/build-push-action@v5.0.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -55,7 +60,6 @@ jobs:
           outputs: type=image,annotation-index.org.opencontainers.image.description=Extract linked metadata from repositories.
 
   push-image:
-    needs: build-image
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     permissions:
@@ -63,23 +67,26 @@ jobs:
       packages: write
 
     steps:
+      # https://github.com/actions/checkout
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: lowercase image name
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
 
+      # https://github.com/docker/login-action
       - name: Log in to the Container registry
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # https://github.com/docker/metadata-action
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 #v4.3.0
+        uses: docker/metadata-action@v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -87,8 +94,9 @@ jobs:
             type=raw,value=${{ needs.build-image.outputs.version_build }},enable=${{ github.event_name == 'push' }}
             type=raw,value=${{ needs.build-image.outputs.version }},enable=${{ github.event_name == 'release' }}
 
+      # https://github.com/docker/build-push-action
       - name: Push Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
+        uses: docker/build-push-action@v5.0.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -9,8 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+      # https://github.com/JRubics/poetry-publish
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.16
+        uses: JRubics/poetry-publish@v1.17
         with:
           pypi_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -10,15 +10,18 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      # https://github.com/actions/setup-python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
+      # https://github.com/snok/install-poetry
       - name: Install Poetry
         uses: snok/install-poetry@v1
 
@@ -51,7 +54,8 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+    # https://github.com/coverallsapp/github-action
     - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         parallel-finished: true

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -7,9 +7,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.16
+      # https://github.com/JRubics/poetry-publish
+        uses: JRubics/poetry-publish@v1.17
         with:
           pypi_token: ${{ secrets.PYPI_TEST_API_TOKEN }}
           repository_name: "testpypi"

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -1,14 +1,25 @@
 name: docs
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'docs/**'
+  
 permissions:
     contents: write
 jobs:
-  docs:
+  docs-build:
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+      
+      # https://github.com/actions/setup-python
+      - uses: actions/setup-python@v4
+      
+      # https://github.com/snok/install-poetry
       - name: Install Poetry
         uses: snok/install-poetry@v1
 
@@ -20,6 +31,29 @@ jobs:
         run: |
           make doc
 
+  docs-push:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+      
+      # https://github.com/actions/setup-python
+      - uses: actions/setup-python@v4
+      
+      # https://github.com/snok/install-poetry
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Install dependencies
+        run: |
+          poetry install --with doc
+
+      - name: Sphinx build
+        run: |
+          make doc
+
+      # https://github.com/peaceiris/actions-gh-pages
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/docs-website' }}


### PR DESCRIPTION
Changes:

- All actions are updated to their latest version 
- All `yml` files are using consistent formatting and versions
- `docker-publish` now triggers only for build&push for any changes to `main` (before it would build+build&push)
- `sphinx-docs` now triggers build for PRs when `docs/**` changes and build+push for any changes to `main`