### PR TITLE
fix(docker): push action was missing buildx

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,6 +75,22 @@ jobs:
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
 
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3.0.0
+
+      - name: Get current release version
+        id: release-version
+        run: |
+          version=$(grep -E '^version += +' pyproject.toml | sed -E 's/.*= +//' | sed "s/['\"]//g")
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "version_build=${version}_"$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_OUTPUT
+
       # https://github.com/docker/login-action
       - name: Log in to the Container registry
         uses: docker/login-action@v3.0.0


### PR DESCRIPTION
After a careful check, I realized the push action doesn't include the`qemu` and `setup buildx` steps, which are [required](https://docs.docker.com/build/ci/github-actions/multi-platform/) and currently present in the building phase.