### PR TITLE
refactor(io): simplify resource interface

### DIFF
--- a/gimie/io.py
+++ b/gimie/io.py
@@ -4,7 +4,7 @@ import io
 import os
 from pathlib import Path
 import requests
-from typing import BinaryIO, Iterator, Optional, Union
+from typing import Iterator, Optional, Union
 
 
 class Resource:
@@ -19,7 +19,7 @@ class Resource:
 
     name: str
 
-    def open(self) -> BinaryIO:
+    def open(self) -> io.RawIOBase:
         raise NotImplementedError
 
 
@@ -35,7 +35,7 @@ class LocalResource(Resource):
     def __init__(self, path: Union[str, os.PathLike]):
         self.path: Path = Path(path)
 
-    def open(self, mode="r") -> Union[BinaryIO, io.RawIOBase]:
+    def open(self, mode="r") -> io.RawIOBase:
         return io.FileIO(self.path, mode)
 
     @property

--- a/gimie/io.py
+++ b/gimie/io.py
@@ -8,7 +8,7 @@ from typing import Iterator, Optional, Union
 
 
 class Resource:
-    """Abstract class for buffered read-only access to local or remote resources via
+    """Abstract class for read-only access to local or remote resources via
     a file-like interface.
 
     Parameters
@@ -24,11 +24,10 @@ class Resource:
 
 
 class LocalResource(Resource):
-    """Providing buffered read-only access to local data.
+    """Providing read-only access to local data via a file-like interface.
 
     Examples
     --------
-    >>> from gimie.io import LocalResource
     >>> resource = LocalResource("README.md")
     """
 
@@ -44,7 +43,7 @@ class LocalResource(Resource):
 
 
 class RemoteResource(Resource):
-    """Provides buffered read-only access to remote data.
+    """Provides read-only access to remote data via a file-like interface.
 
     Parameters
     ----------
@@ -55,9 +54,10 @@ class RemoteResource(Resource):
 
     Examples
     --------
-    >>> from gimie.io import RemoteResource
     >>> url = "https://raw.githubusercontent.com/SDSC-ORD/gimie/main/README.md"
-    >>> resource = RemoteResource("README.md", url)
+    >>> content = RemoteResource("README.md", url).open().read()
+    >>> assert isinstance(content, bytes)
+    >>> assert isinstance(content.decode(), str)
     """
 
     def __init__(self, name: str, url: str, headers: Optional[dict] = None):
@@ -73,16 +73,15 @@ class RemoteResource(Resource):
 
 
 class IterStream(io.RawIOBase):
-    """Wraps an iterator to make it look like a file-like object.
+    """Wraps an iterator under a like a file-like interface.
 
     Parameters
     ----------
     iterator:
-        An iterator that yields bytes.
+        An iterator yielding bytes.
 
     Examples
     --------
-    >>> from gimie.io import IterStream
     >>> stream = IterStream(iter([b"Hello ", b"World"]))
     >>> stream.read()
     b'Hello World'

--- a/gimie/io.py
+++ b/gimie/io.py
@@ -26,12 +26,6 @@ class Resource:
 class LocalResource(Resource):
     """Providing buffered read-only access to local data.
 
-    Parameters
-    ----------
-    name: the name of the resource, typically the filename.
-    url: the URL where the resource. can be downladed from.
-    headers: optional headers to pass to the request.
-
     Examples
     --------
     >>> from gimie.io import LocalResource
@@ -54,9 +48,10 @@ class RemoteResource(Resource):
 
     Parameters
     ----------
-    name: the name of the resource, typically the filename.
-    url: the URL where the resource. can be downladed from.
-    headers: optional headers to pass to the request.
+    url:
+        The URL where the resource. can be downladed from.
+    headers:
+        Optional headers to pass to the request.
 
     Examples
     --------

--- a/gimie/io.py
+++ b/gimie/io.py
@@ -34,8 +34,8 @@ class LocalResource(Resource):
     def __init__(self, path: Union[str, os.PathLike]):
         self.path: Path = Path(path)
 
-    def open(self, mode="r") -> io.RawIOBase:
-        return io.FileIO(self.path, mode)
+    def open(self) -> io.RawIOBase:
+        return io.FileIO(self.path, mode="r")
 
     @property
     def name(self) -> str:

--- a/gimie/io.py
+++ b/gimie/io.py
@@ -57,7 +57,6 @@ class RemoteResource(Resource):
     >>> url = "https://raw.githubusercontent.com/SDSC-ORD/gimie/main/README.md"
     >>> content = RemoteResource("README.md", url).open().read()
     >>> assert isinstance(content, bytes)
-    >>> assert isinstance(content.decode(), str)
     """
 
     def __init__(self, name: str, url: str, headers: Optional[dict] = None):

--- a/gimie/io.py
+++ b/gimie/io.py
@@ -97,17 +97,13 @@ class IterStream(io.RawIOBase):
     def readinto(self, b):
         try:
             l = len(b)  # We're supposed to return at most this much
-
-            if self.leftover:
-                chunk = self.leftover
-            else:
-                chunk = next(self.iterator)
-            # skip empty elements
-            while not chunk:
-                chunk = next(self.iterator)
-
-            output, self.leftover = chunk[:l], chunk[l:]
-            b[: len(output)] = output
-            return len(output)
+            while True:
+                chunk = self.leftover or next(self.iterator)
+                # skip empty elements
+                if not chunk:
+                    continue
+                output, self.leftover = chunk[:l], chunk[l:]
+                b[: len(output)] = output
+                return len(output)
         except StopIteration:
             return 0  # indicate EOF

--- a/gimie/io.py
+++ b/gimie/io.py
@@ -4,16 +4,22 @@ import io
 import os
 from pathlib import Path
 import requests
-from typing import Optional, Union
+from typing import BinaryIO, Iterator, Optional, Union
 
 
 class Resource:
     """Abstract class for buffered read-only access to local or remote resources via
-    a file-like interface."""
+    a file-like interface.
+
+    Parameters
+    ----------
+    name:
+        The name of the resource, typically the filename.
+    """
 
     name: str
 
-    def open(self) -> io.BufferedReader:
+    def open(self) -> BinaryIO:
         raise NotImplementedError
 
 
@@ -35,8 +41,8 @@ class LocalResource(Resource):
     def __init__(self, path: Union[str, os.PathLike]):
         self.path: Path = Path(path)
 
-    def open(self, mode="r") -> io.BufferedReader:
-        return io.BufferedReader(io.FileIO(self.path, mode))
+    def open(self, mode="r") -> Union[BinaryIO, io.RawIOBase]:
+        return io.FileIO(self.path, mode)
 
     @property
     def name(self) -> str:
@@ -64,42 +70,42 @@ class RemoteResource(Resource):
         self.url = url
         self.headers = headers or {}
 
-    def open(self) -> io.BufferedReader:
+    def open(self) -> io.RawIOBase:
         resp = requests.get(
             self.url, headers=self.headers, stream=True
         ).iter_content(chunk_size=128)
-        return iterable_to_stream(resp)
+        return IterStream(resp)
 
 
-def iterable_to_stream(
-    iterable, buffer_size=io.DEFAULT_BUFFER_SIZE
-) -> io.BufferedReader:
+class IterStream(io.RawIOBase):
+    """Wraps an iterator to make it look like a file-like object.
+
+    Parameters
+    ----------
+    iterator:
+        An iterator that yields bytes.
+
+    Examples
+    --------
+    >>> from gimie.io import IterStream
+    >>> stream = IterStream(iter([b"Hello ", b"World"]))
+    >>> stream.read()
+    b'Hello World'
     """
-    Converts an iterable yielding bytestrings to a read-only input stream.
-    Lets you use an iterable (e.g. a generator) that yields bytestrings as a read-only
-    input stream.
 
-    The stream implements Python 3's newer I/O API (available in Python 2's io module).
-    For efficiency, the stream is buffered.
+    def __init__(self, iterator: Iterator[bytes]):
+        self.leftover = b""
+        self.iterator = iterator
 
-    credits: https://stackoverflow.com/a/20260030/8440675
-    """
+    def readable(self):
+        return True
 
-    class IterStream(io.RawIOBase):
-        def __init__(self):
-            self.leftover = ""
-
-        def readable(self):
-            return True
-
-        def readinto(self, b):
-            try:
-                l = len(b)  # We're supposed to return at most this much
-                chunk = self.leftover or next(iterable)
-                output, self.leftover = chunk[:l], chunk[l:]
-                b[: len(output)] = output
-                return len(output)
-            except StopIteration:
-                return 0  # indicate EOF
-
-    return io.BufferedReader(IterStream(), buffer_size=buffer_size)
+    def readinto(self, b):
+        try:
+            l = len(b)  # We're supposed to return at most this much
+            chunk = self.leftover or next(self.iterator)
+            output, self.leftover = chunk[:l], chunk[l:]
+            b[: len(output)] = output
+            return len(output)
+        except StopIteration:
+            return 0  # indicate EOF


### PR DESCRIPTION
This PR simplifies the `Resource` interface and makes it more flexible:

* Removes buffering-by-default, letting the user choose whether they need it
* Move IterStream to top-level for clarity
* Format + expand docstrings

Thanks @jojolebarjos for suggestions :)