### PR TITLE
chore: rm importlib from deps

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "gimie"
 copyright = "2023, SDSC-ORD"
 author = "SDSC-ORD"
-release = "0.6.0"
+release = "0.6.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,17 +32,16 @@ typer = "^0.7.0"
 calamus = "^0.4.2"
 requests = "^2.28.2"
 python-dotenv = "^0.21.1"
-pre-commit = "^3.0.0"
-importlib = "^1.0.4"
 python-dateutil = "^2.8.2"
 scancode-toolkit-mini = "^32.0.8"
 spdx-license-list = "^3.22"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.2.0"
 black = "^22.10.0"
-pytest-cov = "^4.1.0"
 coveralls = "^3.3.1"
+pre-commit = "^3.0.0"
+pytest = "^7.2.0"
+pytest-cov = "^4.1.0"
 
 
 [tool.poetry.group.doc.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [tool.poetry]
 name = "gimie"
-version = "0.6.0"
+version = "0.6.1"
 description = "Extract structured metadata from git repositories."
 authors = ["Swiss Data Science Center <contact@datascience.ch>"]
 license = "Apache-2.0"


### PR DESCRIPTION
importlib is in the standard library and we should not pin it in dependencies at the risk of breaking compatibility with other packages.
This PR removes it from dependencies and increments the patch version number.