### PR TITLE
docs: update gimie API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ g = proj.extract()
 g_in_ttl = g.serialize(format='ttl')
 print(g_in_ttl)
 ```
-
+For more advanced use see [the documentation](https://sdsc-ordes.github.io/gimie/intro/usage_python.html).
 ## Outputs
 
 The default output is [Turtle](https://www.w3.org/TR/turtle/), a textual syntax for [RDF](https://en.wikipedia.org/wiki/Resource_Description_Framework) data model. We follow the schema recommended by [codemeta](https://codemeta.github.io/).

--- a/README.md
+++ b/README.md
@@ -77,25 +77,12 @@ from gimie.project import Project
 proj = Project("https://github.com/numpy/numpy)
 
 # To retrieve the rdflib.Graph object
-g = proj.to_graph()
+g = proj.extract()
 
 # To retrieve the serialized graph
-proj.serialize(format='ttl')
+g_in_ttl = g.serialize(format='ttl')
+print(g_in_ttl)
 ```
-
-Or to extract only from a specific source:
-```python
-from gimie.sources.github import GithubExtractor
-gh = GithubExtractor('https://github.com/sdsc-ordes/gimie')
-gh.extract()
-
-# To retrieve the rdflib.Graph object
-g = gh.to_graph()
-
-# To retrieve the serialized graph
-gh.serialize(format='ttl')
-```
-[For a GitLab project, replace `gimie.sources.github` by `gimie.sources.gitlab`, `GithubExtractor` by `GitlabExtractor`, as well as the URL to the GitLab project.]
 
 ## Outputs
 

--- a/docs/intro/usage_python.rst
+++ b/docs/intro/usage_python.rst
@@ -3,34 +3,50 @@ Python Usage
 
 Gimie can be used as a python library. Either to run the end-to-end extraction process on an input URL, or only a specific extractor.
 
-The end-to-end extraction is performed by ``gimie.Project`` and will automatically detect the git-provider:
+The end-to-end extraction is performed by ``gimie.Project`` and will automatically detect the git-provider and return directly an `rdflib.Graph` object. After extracting data from the git repository, parsers are executed on the files contents to enrich the graph with additional information.:
 
 .. code-block:: python
 
    from gimie.project import Project
-   url = 'https://github.com/foo/bar'
+   url = 'https://github.com/apache/pulsar'
    proj = Project(url)
+   g = proj.extract()
 
 
 A specific extractor can also be used, for example to use with GitLab projects:
 
 .. code-block:: python
 
-   from gimie.sources.gitlab import GitlabExtractor
-   url = "https://gitlab.com/foo/bar"
+   from gimie.extractors import GitlabExtractor
+   url = "https://gitlab.com/inkscape/inkscape"
    extractor = GitlabExtractor(url)
-   extractor.extract()
+   repo = extractor.extract()
 
 
-Once a project's metadata has been extracted, it can be stored as an rdflib graph, or serialized to RDF triples:
+Unlike `Project`, extractors only extract data from the git repository without running any parser, and return a `Repository` object.
+
+The `Repository` object can be serialized to RDF or converted to an rdflib graph:
 
 .. code-block:: python
 
-   import rdflib
-   graph: rdflib.Graph = proj.to_graph()
+   type(repo)
+   # gimie.models.Repository
+   repo.name
+   # 'inkscape/inkscape'
+   repo.prog_langs
+   # ['C++', 'C', 'CMake', 'HTML', 'Python']
+   repo.serialize(format='json-ld', destination='inkscape.json')
+   g = repo.to_graph()
+   type(g)
+   # rdflib.graph.Graph
 
-   # serialize project directly as an RDF file
-   proj.serialize(format='json-ld', destination='foobar.json')
+Extractors also have a `list_files()` method which provides handles to a streamable file-like interface for files in the root of the repository.
 
+.. code-block:: python
 
-Extractors also support the ``to_graph()`` and ``serialize()`` methods.
+   handles = extractor.list_files()
+   readme_handle = handles[11]
+   readme_handle.path
+   # PosixPath('README.md')
+   readme_handle.open().readlines()[:2]
+   # [b'Inkscape. Draw Freely.\n', b'======================\n']

--- a/docs/intro/usage_python.rst
+++ b/docs/intro/usage_python.rst
@@ -18,7 +18,7 @@ A specific extractor can also be used, for example to use with GitLab projects:
 .. code-block:: python
 
    from gimie.extractors import GitlabExtractor
-   url = "https://gitlab.com/inkscape/inkscape"
+   url = "https://gitlab.com/data-custodian/custodian"
    extractor = GitlabExtractor(url)
    repo = extractor.extract()
 
@@ -32,10 +32,10 @@ The `Repository` object can be serialized to RDF or converted to an rdflib graph
    type(repo)
    # gimie.models.Repository
    repo.name
-   # 'inkscape/inkscape'
+   # 'data-custodian/custodian'
    repo.prog_langs
-   # ['C++', 'C', 'CMake', 'HTML', 'Python']
-   repo.serialize(format='json-ld', destination='inkscape.json')
+   # ['Go', 'Dockerfile', 'Smarty', 'Shell', 'Makefile']
+   repo.serialize(format='json-ld', destination='custodian.json')
    g = repo.to_graph()
    type(g)
    # rdflib.graph.Graph
@@ -49,4 +49,27 @@ Extractors also have a `list_files()` method which provides handles to a streama
    readme_handle.path
    # PosixPath('README.md')
    readme_handle.open().readlines()[:2]
-   # [b'Inkscape. Draw Freely.\n', b'======================\n']
+   # [b'# The Swiss Data Custodian\n', b'\n']
+
+
+Parsers can also be run manually on the files contents:
+
+
+.. code-block:: python
+
+   from gimie.parsers import LicenseParser
+   parser = LicenseParser()
+   license_handle = handles[8]
+   license_contents = license_handle.open().read()
+   parser.parse(license_contents)
+   # {(rdflib.term.URIRef('http://schema.org/license'), rdflib.term.URIRef('https://spdx.org/licenses/AGPL-3.0-only.html'))}
+
+
+There is also a helper function to run parsers on a list of files,
+selecting the correct parser based on file names:
+
+.. code-block:: python
+
+   from gimie.parsers import parse_files
+   parse_files(handles)
+   # {(rdflib.term.URIRef('http://schema.org/license'), rdflib.term.URIRef('https://spdx.org/licenses/AGPL-3.0-only.html'))}


### PR DESCRIPTION
The way of transforming to a graph has changed, so the instructions on how to use gimie as a python package need to be updated