### PR TITLE
feat: add publiccode.yml parser

### DIFF
--- a/gimie/extractors/git.py
+++ b/gimie/extractors/git.py
@@ -31,6 +31,7 @@ import pydriller
 from gimie.io import LocalResource
 from gimie.models import Person, Repository
 from gimie.extractors.abstract import Extractor
+from gimie.utils.uri import sanitize_identifier
 from pathlib import Path
 
 
@@ -152,7 +153,7 @@ class GitExtractor(Extractor):
         if name is None:
             uid = str(uuid.uuid4())
         else:
-            uid = name.replace(" ", "_").lower()
+            uid = sanitize_identifier(name)
         dev_id = f"{self.url}/{uid}"
         return Person(
             _id=dev_id,

--- a/gimie/parsers/__init__.py
+++ b/gimie/parsers/__init__.py
@@ -81,7 +81,10 @@ def select_parser(
         name = "license"
     elif path.name == "CITATION.cff" and len(path.parts) == 1:
         name = "cff"
-    elif path.name in ("publiccode.yml", "publiccode.yaml") and len(path.parts) == 1:
+    elif (
+        path.name in ("publiccode.yml", "publiccode.yaml")
+        and len(path.parts) == 1
+    ):
         name = "publiccode"
     else:
         return None

--- a/gimie/parsers/__init__.py
+++ b/gimie/parsers/__init__.py
@@ -24,6 +24,7 @@ from gimie.io import Resource
 from gimie.parsers.abstract import Parser
 from gimie.parsers.license import LicenseParser, is_license_filename
 from gimie.parsers.cff import CffParser
+from gimie.parsers.publiccode import PublicCodeParser
 
 from rdflib import Graph
 
@@ -36,6 +37,7 @@ class ParserInfo(NamedTuple):
 PARSERS = {
     "license": ParserInfo(default=True, type=LicenseParser),
     "cff": ParserInfo(default=True, type=CffParser),
+    "publiccode": ParserInfo(default=True, type=PublicCodeParser),
 }
 
 
@@ -79,6 +81,8 @@ def select_parser(
         name = "license"
     elif path.name == "CITATION.cff" and len(path.parts) == 1:
         name = "cff"
+    elif path.name in ("publiccode.yml", "publiccode.yaml") and len(path.parts) == 1:
+        name = "publiccode"
     else:
         return None
 

--- a/gimie/parsers/publiccode.py
+++ b/gimie/parsers/publiccode.py
@@ -1,0 +1,154 @@
+# Gimie
+# Copyright 2022 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parse metadata from publiccode.yml files (v0.5.0 standard).
+
+Only extracts properties that are not already provided by
+extractors or other parsers (license, description, version, etc.).
+Currently extracts:
+- maintenance/contacts -> schema:author Person nodes
+- isBasedOn -> schema:isBasedOn
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import yaml
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import RDF
+
+from gimie import logger
+from gimie.graph.namespaces import SDO
+from gimie.parsers.abstract import Parser
+
+
+def _sanitize_identifier(name: str) -> str:
+    """Create a URL-safe identifier from a contact name.
+
+    >>> _sanitize_identifier("John Doe")
+    'john_doe'
+    """
+    return name.strip().replace(" ", "_").lower()
+
+
+class PublicCodeParser(Parser):
+    """Parse metadata from publiccode.yml (v0.5.0)."""
+
+    def __init__(self, subject: str):
+        super().__init__(subject)
+
+    def parse(self, data: bytes) -> Graph:
+        """Extract RDF triples from a publiccode.yml file.
+
+        Maps publiccode.yml fields to schema.org properties compatible
+        with gimie's existing vocabulary.
+        """
+        graph = Graph()
+
+        try:
+            pc = yaml.safe_load(data.decode())
+        except (yaml.YAMLError, UnicodeDecodeError):
+            logger.warning("Cannot read publiccode.yml, skipped.")
+            return graph
+
+        if not isinstance(pc, dict):
+            logger.warning("publiccode.yml is not a valid YAML mapping.")
+            return graph
+
+        self._add_is_based_on(graph, pc)
+        self._add_contacts(graph, pc)
+
+        return graph
+
+    def _add_description(self, graph: Graph, pc: Dict[str, Any]) -> None:
+        description = _get_description(pc)
+        if description:
+            graph.add(
+                (self.subject, SDO.description, Literal(description))
+            )
+
+    def _add_version(self, graph: Graph, pc: Dict[str, Any]) -> None:
+        version = pc.get("softwareVersion")
+        if version:
+            graph.add((self.subject, SDO.version, Literal(str(version))))
+
+    def _add_release_date(self, graph: Graph, pc: Dict[str, Any]) -> None:
+        release_date = pc.get("releaseDate")
+        if release_date:
+            graph.add(
+                (
+                    self.subject,
+                    SDO.datePublished,
+                    Literal(str(release_date)),
+                )
+            )
+
+    def _add_licenses(self, graph: Graph, pc: Dict[str, Any]) -> None:
+        legal = pc.get("legal")
+        if not isinstance(legal, dict):
+            return
+        license_expr = legal.get("license")
+        if not license_expr:
+            return
+        for spdx_id in _parse_spdx_expression(str(license_expr)):
+            url = _spdx_id_to_url(spdx_id)
+            graph.add((self.subject, SDO.license, URIRef(url)))
+
+    def _add_is_based_on(self, graph: Graph, pc: Dict[str, Any]) -> None:
+        is_based_on = pc.get("isBasedOn")
+        if not is_based_on:
+            return
+        urls = (
+            is_based_on if isinstance(is_based_on, list) else [is_based_on]
+        )
+        for url in urls:
+            graph.add((self.subject, SDO.isBasedOn, URIRef(str(url))))
+
+    def _add_contacts(self, graph: Graph, pc: Dict[str, Any]) -> None:
+        maintenance = pc.get("maintenance")
+        if not isinstance(maintenance, dict):
+            return
+        contacts = maintenance.get("contacts")
+        if not isinstance(contacts, list):
+            return
+
+        for contact in contacts:
+            if not isinstance(contact, dict):
+                continue
+            name = contact.get("name")
+            if not name:
+                continue
+
+            uid = _sanitize_identifier(name)
+            person_uri = URIRef(f"{self.subject}/{uid}")
+
+            graph.add((self.subject, SDO.author, person_uri))
+            graph.add((person_uri, RDF.type, SDO.Person))
+            graph.add((person_uri, SDO.name, Literal(name)))
+            graph.add(
+                (person_uri, SDO.identifier, Literal(uid))
+            )
+
+            email = contact.get("email")
+            if email:
+                graph.add((person_uri, SDO.email, Literal(email)))
+
+            affiliation = contact.get("affiliation")
+            if affiliation:
+                graph.add(
+                    (person_uri, SDO.affiliation, Literal(affiliation))
+                )

--- a/gimie/parsers/publiccode.py
+++ b/gimie/parsers/publiccode.py
@@ -57,11 +57,11 @@ class PublicCodeParser(Parser):
                 graph.add((person_uri, SDO.name, Literal(contact["name"])))
                 graph.add((person_uri, SDO.identifier, Literal(uid)))
 
-                if "email" in contact:
+                if contact.get("email") is not None:
                     graph.add(
                         (person_uri, SDO.email, Literal(contact["email"]))
                     )
-                if "affiliation" in contact:
+                if contact.get("affiliation") is not None:
                     graph.add(
                         (
                             person_uri,
@@ -153,10 +153,8 @@ def get_publiccode_contacts(pc: dict) -> Optional[List[Dict[str, str]]]:
         if not name:
             continue
         entry: Dict[str, str] = {"name": name}
-        if contact.get("email"):
-            entry["email"] = contact["email"]
-        if contact.get("affiliation"):
-            entry["affiliation"] = contact["affiliation"]
+        entry["email"] = contact.get("email")
+        entry["affiliation"] = contact.get("affiliation")
         result.append(entry)
 
     return result if result else None

--- a/gimie/parsers/publiccode.py
+++ b/gimie/parsers/publiccode.py
@@ -45,9 +45,7 @@ class PublicCodeParser(Parser):
 
         if is_based_on:
             for url in is_based_on:
-                graph.add(
-                    (self.subject, SDO.isBasedOn, URIRef(url))
-                )
+                graph.add((self.subject, SDO.isBasedOn, URIRef(url)))
 
         if contacts:
             for contact in contacts:

--- a/gimie/parsers/publiccode.py
+++ b/gimie/parsers/publiccode.py
@@ -134,7 +134,7 @@ def get_publiccode_contacts(pc: dict) -> Optional[List[Dict[str, str]]]:
     Examples
     --------
     >>> get_publiccode_contacts({"maintenance": {"contacts": [{"name": "Jane Doe", "email": "jane@example.org"}]}})
-    [{'name': 'Jane Doe', 'email': 'jane@example.org'}]
+    [{'name': 'Jane Doe', 'email': 'jane@example.org', 'affiliation': None}]
     >>> get_publiccode_contacts({"name": "test"})
     """
     maintenance = pc.get("maintenance")

--- a/gimie/parsers/publiccode.py
+++ b/gimie/parsers/publiccode.py
@@ -14,18 +14,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Parse metadata from publiccode.yml files (v0.5.0 standard).
-
-Only extracts properties that are not already provided by
-extractors or other parsers (license, description, version, etc.).
-Currently extracts:
-- maintenance/contacts -> schema:author Person nodes
-- isBasedOn -> schema:isBasedOn
-"""
+"""Parse metadata from publiccode.yml files (v0.5.0 standard)."""
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Dict, List, Optional
 
 import yaml
 from rdflib import Graph, Literal, URIRef
@@ -34,121 +27,138 @@ from rdflib.namespace import RDF
 from gimie import logger
 from gimie.graph.namespaces import SDO
 from gimie.parsers.abstract import Parser
-
-
-def _sanitize_identifier(name: str) -> str:
-    """Create a URL-safe identifier from a contact name.
-
-    >>> _sanitize_identifier("John Doe")
-    'john_doe'
-    """
-    return name.strip().replace(" ", "_").lower()
+from gimie.utils.uri import sanitize_identifier
 
 
 class PublicCodeParser(Parser):
     """Parse metadata from publiccode.yml (v0.5.0)."""
 
-    def __init__(self, subject: str):
-        super().__init__(subject)
-
     def parse(self, data: bytes) -> Graph:
-        """Extract RDF triples from a publiccode.yml file.
-
-        Maps publiccode.yml fields to schema.org properties compatible
-        with gimie's existing vocabulary.
-        """
         graph = Graph()
 
-        try:
-            pc = yaml.safe_load(data.decode())
-        except (yaml.YAMLError, UnicodeDecodeError):
-            logger.warning("Cannot read publiccode.yml, skipped.")
+        pc = _parse_yaml(data)
+        if pc is None:
             return graph
 
-        if not isinstance(pc, dict):
-            logger.warning("publiccode.yml is not a valid YAML mapping.")
-            return graph
+        is_based_on = get_publiccode_is_based_on(pc)
+        contacts = get_publiccode_contacts(pc)
 
-        self._add_is_based_on(graph, pc)
-        self._add_contacts(graph, pc)
+        if is_based_on:
+            for url in is_based_on:
+                graph.add(
+                    (self.subject, SDO.isBasedOn, URIRef(url))
+                )
+
+        if contacts:
+            for contact in contacts:
+                uid = sanitize_identifier(contact["name"])
+                person_uri = URIRef(f"{self.subject}/{uid}")
+
+                graph.add((self.subject, SDO.author, person_uri))
+                graph.add((person_uri, RDF.type, SDO.Person))
+                graph.add((person_uri, SDO.name, Literal(contact["name"])))
+                graph.add((person_uri, SDO.identifier, Literal(uid)))
+
+                if "email" in contact:
+                    graph.add(
+                        (person_uri, SDO.email, Literal(contact["email"]))
+                    )
+                if "affiliation" in contact:
+                    graph.add(
+                        (
+                            person_uri,
+                            SDO.affiliation,
+                            Literal(contact["affiliation"]),
+                        )
+                    )
 
         return graph
 
-    def _add_description(self, graph: Graph, pc: Dict[str, Any]) -> None:
-        description = _get_description(pc)
-        if description:
-            graph.add(
-                (self.subject, SDO.description, Literal(description))
-            )
 
-    def _add_version(self, graph: Graph, pc: Dict[str, Any]) -> None:
-        version = pc.get("softwareVersion")
-        if version:
-            graph.add((self.subject, SDO.version, Literal(str(version))))
+def _parse_yaml(data: bytes) -> Optional[dict]:
+    """Parse publiccode.yml bytes into a dict.
 
-    def _add_release_date(self, graph: Graph, pc: Dict[str, Any]) -> None:
-        release_date = pc.get("releaseDate")
-        if release_date:
-            graph.add(
-                (
-                    self.subject,
-                    SDO.datePublished,
-                    Literal(str(release_date)),
-                )
-            )
+    Returns None on invalid YAML or non-dict content.
+    """
+    try:
+        pc = yaml.safe_load(data.decode())
+    except (yaml.YAMLError, UnicodeDecodeError):
+        logger.warning("Cannot read publiccode.yml, skipped.")
+        return None
 
-    def _add_licenses(self, graph: Graph, pc: Dict[str, Any]) -> None:
-        legal = pc.get("legal")
-        if not isinstance(legal, dict):
-            return
-        license_expr = legal.get("license")
-        if not license_expr:
-            return
-        for spdx_id in _parse_spdx_expression(str(license_expr)):
-            url = _spdx_id_to_url(spdx_id)
-            graph.add((self.subject, SDO.license, URIRef(url)))
+    if not isinstance(pc, dict):
+        return None
 
-    def _add_is_based_on(self, graph: Graph, pc: Dict[str, Any]) -> None:
-        is_based_on = pc.get("isBasedOn")
-        if not is_based_on:
-            return
-        urls = (
-            is_based_on if isinstance(is_based_on, list) else [is_based_on]
-        )
-        for url in urls:
-            graph.add((self.subject, SDO.isBasedOn, URIRef(str(url))))
+    return pc
 
-    def _add_contacts(self, graph: Graph, pc: Dict[str, Any]) -> None:
-        maintenance = pc.get("maintenance")
-        if not isinstance(maintenance, dict):
-            return
-        contacts = maintenance.get("contacts")
-        if not isinstance(contacts, list):
-            return
 
-        for contact in contacts:
-            if not isinstance(contact, dict):
-                continue
-            name = contact.get("name")
-            if not name:
-                continue
+def get_publiccode_is_based_on(pc: dict) -> Optional[List[str]]:
+    """Given a parsed publiccode.yml dict, return the isBasedOn URLs, if any.
 
-            uid = _sanitize_identifier(name)
-            person_uri = URIRef(f"{self.subject}/{uid}")
+    Parameters
+    ----------
+    pc
+        The parsed publiccode.yml content as a dict.
 
-            graph.add((self.subject, SDO.author, person_uri))
-            graph.add((person_uri, RDF.type, SDO.Person))
-            graph.add((person_uri, SDO.name, Literal(name)))
-            graph.add(
-                (person_uri, SDO.identifier, Literal(uid))
-            )
+    Returns
+    -------
+    list of str, optional
+        URLs of upstream repositories.
 
-            email = contact.get("email")
-            if email:
-                graph.add((person_uri, SDO.email, Literal(email)))
+    Examples
+    --------
+    >>> get_publiccode_is_based_on({"isBasedOn": "https://github.com/org/upstream"})
+    ['https://github.com/org/upstream']
+    >>> get_publiccode_is_based_on({"name": "test"})
+    """
+    is_based_on = pc.get("isBasedOn")
+    if not is_based_on:
+        return None
 
-            affiliation = contact.get("affiliation")
-            if affiliation:
-                graph.add(
-                    (person_uri, SDO.affiliation, Literal(affiliation))
-                )
+    urls = is_based_on if isinstance(is_based_on, list) else [is_based_on]
+    return [str(url) for url in urls]
+
+
+def get_publiccode_contacts(pc: dict) -> Optional[List[Dict[str, str]]]:
+    """Given a parsed publiccode.yml dict, return maintenance contacts, if any.
+
+    Parameters
+    ----------
+    pc
+        The parsed publiccode.yml content as a dict.
+
+    Returns
+    -------
+    list of dict, optional
+        Each dict contains 'name' (mandatory) and optionally
+        'email' and 'affiliation'.
+
+    Examples
+    --------
+    >>> get_publiccode_contacts({"maintenance": {"contacts": [{"name": "Jane Doe", "email": "jane@example.org"}]}})
+    [{'name': 'Jane Doe', 'email': 'jane@example.org'}]
+    >>> get_publiccode_contacts({"name": "test"})
+    """
+    maintenance = pc.get("maintenance")
+    if not isinstance(maintenance, dict):
+        return None
+
+    contacts = maintenance.get("contacts")
+    if not isinstance(contacts, list):
+        return None
+
+    result = []
+    for contact in contacts:
+        if not isinstance(contact, dict):
+            continue
+        name = contact.get("name")
+        if not name:
+            continue
+        entry: Dict[str, str] = {"name": name}
+        if contact.get("email"):
+            entry["email"] = contact["email"]
+        if contact.get("affiliation"):
+            entry["affiliation"] = contact["affiliation"]
+        result.append(entry)
+
+    return result if result else None

--- a/gimie/utils/uri.py
+++ b/gimie/utils/uri.py
@@ -23,6 +23,17 @@ import re
 from gimie.graph.namespaces import GIMIE
 
 
+def sanitize_identifier(name: str) -> str:
+    """Create a URL-safe identifier from a name.
+
+    >>> sanitize_identifier("John Doe")
+    'john_doe'
+    >>> sanitize_identifier("Alice")
+    'alice'
+    """
+    return name.strip().replace(" ", "_").lower()
+
+
 def validate_url(url: str):
     """Checks if input is a valid URL.
     credits: https://stackoverflow.com/a/38020041

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,39 @@
+publiccodeYmlVersion: 0.5.0
+name: gimie
+url: https://github.com/sdsc-ordes/gimie
+softwareVersion: 0.7.2
+platforms:
+  - windows
+  - mac
+  - linux
+fundedBy:
+  - name: Swiss Data Science Center
+    uri: https://ror.org/02hdt9m26
+developmentStatus: development
+softwareType: library
+organisation:
+  uri: https://ld.admin.ch/office/VI.2.2.6
+  name: Swiss Federal Institute of Technology Lausanne (EPFL)
+description:
+  en:
+    localisedName: gimie
+    shortDescription: Extract linked metadata from repositories
+    longDescription: Gimie (GIt Meta Information Extractor) is a python library and
+      command line tool to extract structured metadata from git repositories.
+      Scientific code repositories contain valuable metadata which can be used
+      to enrich existing catalogues, platforms or databases. This tool aims to
+      easily extract structured metadata from a generic git repositories. It can
+      extract extract metadata from the Git provider (GitHub or GitLab) or from
+      the git index itself.
+    features:
+      - data extraction
+      - cli
+      - python package
+legal:
+  license: Apache-2.0
+maintenance:
+  type: none
+localisation:
+  localisationReady: false
+  availableLanguages:
+    - en

--- a/tests/test_publiccode.py
+++ b/tests/test_publiccode.py
@@ -113,13 +113,6 @@ def test_parse_builds_graph():
     assert not list(graph.objects(john_uri, SDO.email))
 
 
-def test_parse_does_not_add_extractor_fields():
-    graph = PublicCodeParser(subject=SUBJECT).parse(FULL_PUBLICCODE)
-    assert not list(graph.objects(URIRef(SUBJECT), SDO.description))
-    assert not list(graph.objects(URIRef(SUBJECT), SDO.version))
-    assert not list(graph.objects(URIRef(SUBJECT), SDO.datePublished))
-    assert not list(graph.objects(URIRef(SUBJECT), SDO.license))
-
 
 def test_parse_invalid_yaml():
     graph = PublicCodeParser(subject=SUBJECT).parse(b"{{invalid yaml")

--- a/tests/test_publiccode.py
+++ b/tests/test_publiccode.py
@@ -85,7 +85,7 @@ def test_get_contacts():
         "email": "jane@example.org",
         "affiliation": "Example Corp",
     }
-    assert contacts[1] == {"name": "John Smith"}
+    assert contacts[1] == {"name": "John Smith", "email": None, "affiliation": None}
 
 
 def test_get_contacts_missing():

--- a/tests/test_publiccode.py
+++ b/tests/test_publiccode.py
@@ -4,7 +4,8 @@ from rdflib.namespace import RDF
 from gimie.graph.namespaces import SDO
 from gimie.parsers.publiccode import (
     PublicCodeParser,
-    _sanitize_identifier,
+    get_publiccode_contacts,
+    get_publiccode_is_based_on,
 )
 
 SUBJECT = "https://example.org/repo"
@@ -47,19 +48,57 @@ localisation:
 """
 
 
-def test_sanitize_identifier():
-    assert _sanitize_identifier("Jane Doe") == "jane_doe"
-    assert _sanitize_identifier("Alice") == "alice"
+def test_get_is_based_on():
+    assert get_publiccode_is_based_on(
+        {"isBasedOn": "https://github.com/org/upstream"}
+    ) == ["https://github.com/org/upstream"]
 
 
-def test_parse_extracts_is_based_on():
+def test_get_is_based_on_list():
+    assert get_publiccode_is_based_on(
+        {"isBasedOn": ["https://a.com", "https://b.com"]}
+    ) == ["https://a.com", "https://b.com"]
+
+
+def test_get_is_based_on_missing():
+    assert get_publiccode_is_based_on({"name": "test"}) is None
+
+
+def test_get_contacts():
+    pc = {
+        "maintenance": {
+            "contacts": [
+                {
+                    "name": "Jane Doe",
+                    "email": "jane@example.org",
+                    "affiliation": "Example Corp",
+                },
+                {"name": "John Smith"},
+            ]
+        }
+    }
+    contacts = get_publiccode_contacts(pc)
+    assert contacts is not None
+    assert len(contacts) == 2
+    assert contacts[0] == {
+        "name": "Jane Doe",
+        "email": "jane@example.org",
+        "affiliation": "Example Corp",
+    }
+    assert contacts[1] == {"name": "John Smith"}
+
+
+def test_get_contacts_missing():
+    assert get_publiccode_contacts({"name": "test"}) is None
+
+
+def test_parse_builds_graph():
     graph = PublicCodeParser(subject=SUBJECT).parse(FULL_PUBLICCODE)
-    parents = list(graph.objects(URIRef(SUBJECT), SDO.isBasedOn))
-    assert URIRef("https://github.com/org/upstream") in parents
 
+    assert URIRef("https://github.com/org/upstream") in list(
+        graph.objects(URIRef(SUBJECT), SDO.isBasedOn)
+    )
 
-def test_parse_extracts_contacts():
-    graph = PublicCodeParser(subject=SUBJECT).parse(FULL_PUBLICCODE)
     authors = list(graph.objects(URIRef(SUBJECT), SDO.author))
     assert len(authors) == 2
 
@@ -75,24 +114,11 @@ def test_parse_extracts_contacts():
 
 
 def test_parse_does_not_add_extractor_fields():
-    """Fields already covered by extractors/parsers are not duplicated."""
     graph = PublicCodeParser(subject=SUBJECT).parse(FULL_PUBLICCODE)
     assert not list(graph.objects(URIRef(SUBJECT), SDO.description))
     assert not list(graph.objects(URIRef(SUBJECT), SDO.version))
     assert not list(graph.objects(URIRef(SUBJECT), SDO.datePublished))
     assert not list(graph.objects(URIRef(SUBJECT), SDO.license))
-
-
-def test_parse_no_contacts():
-    data = b"""
-publiccodeYmlVersion: "0.5"
-name: test
-url: https://example.org/test
-legal:
-  license: MIT
-"""
-    graph = PublicCodeParser(subject=SUBJECT).parse(data)
-    assert not list(graph.objects(URIRef(SUBJECT), SDO.author))
 
 
 def test_parse_invalid_yaml():

--- a/tests/test_publiccode.py
+++ b/tests/test_publiccode.py
@@ -113,7 +113,6 @@ def test_parse_builds_graph():
     assert not list(graph.objects(john_uri, SDO.email))
 
 
-
 def test_parse_invalid_yaml():
     graph = PublicCodeParser(subject=SUBJECT).parse(b"{{invalid yaml")
     assert len(graph) == 0

--- a/tests/test_publiccode.py
+++ b/tests/test_publiccode.py
@@ -85,7 +85,11 @@ def test_get_contacts():
         "email": "jane@example.org",
         "affiliation": "Example Corp",
     }
-    assert contacts[1] == {"name": "John Smith", "email": None, "affiliation": None}
+    assert contacts[1] == {
+        "name": "John Smith",
+        "email": None,
+        "affiliation": None,
+    }
 
 
 def test_get_contacts_missing():

--- a/tests/test_publiccode.py
+++ b/tests/test_publiccode.py
@@ -1,0 +1,105 @@
+from rdflib import URIRef, Literal
+from rdflib.namespace import RDF
+
+from gimie.graph.namespaces import SDO
+from gimie.parsers.publiccode import (
+    PublicCodeParser,
+    _sanitize_identifier,
+)
+
+SUBJECT = "https://example.org/repo"
+
+FULL_PUBLICCODE = b"""
+publiccodeYmlVersion: "0.5"
+name: example-app
+url: https://github.com/org/example-app
+softwareVersion: "2.1.0"
+releaseDate: "2024-06-15"
+platforms:
+  - web
+developmentStatus: stable
+softwareType: standalone/web
+isBasedOn: https://github.com/org/upstream
+description:
+  en:
+    shortDescription: A short description of the app.
+    longDescription: >
+      This is a much longer description of the application
+      that goes into more detail about what it does and why.
+    features:
+      - Feature one
+      - Feature two
+legal:
+  license: Apache-2.0 OR MIT
+  mainCopyrightOwner: Example Corp
+maintenance:
+  type: community
+  contacts:
+    - name: Jane Doe
+      email: jane@example.org
+      affiliation: Example Corp
+    - name: John Smith
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - en
+    - it
+"""
+
+
+def test_sanitize_identifier():
+    assert _sanitize_identifier("Jane Doe") == "jane_doe"
+    assert _sanitize_identifier("Alice") == "alice"
+
+
+def test_parse_extracts_is_based_on():
+    graph = PublicCodeParser(subject=SUBJECT).parse(FULL_PUBLICCODE)
+    parents = list(graph.objects(URIRef(SUBJECT), SDO.isBasedOn))
+    assert URIRef("https://github.com/org/upstream") in parents
+
+
+def test_parse_extracts_contacts():
+    graph = PublicCodeParser(subject=SUBJECT).parse(FULL_PUBLICCODE)
+    authors = list(graph.objects(URIRef(SUBJECT), SDO.author))
+    assert len(authors) == 2
+
+    jane_uri = URIRef(f"{SUBJECT}/jane_doe")
+    assert (jane_uri, RDF.type, SDO.Person) in graph
+    assert (jane_uri, SDO.name, Literal("Jane Doe")) in graph
+    assert (jane_uri, SDO.email, Literal("jane@example.org")) in graph
+    assert (jane_uri, SDO.affiliation, Literal("Example Corp")) in graph
+
+    john_uri = URIRef(f"{SUBJECT}/john_smith")
+    assert (john_uri, SDO.name, Literal("John Smith")) in graph
+    assert not list(graph.objects(john_uri, SDO.email))
+
+
+def test_parse_does_not_add_extractor_fields():
+    """Fields already covered by extractors/parsers are not duplicated."""
+    graph = PublicCodeParser(subject=SUBJECT).parse(FULL_PUBLICCODE)
+    assert not list(graph.objects(URIRef(SUBJECT), SDO.description))
+    assert not list(graph.objects(URIRef(SUBJECT), SDO.version))
+    assert not list(graph.objects(URIRef(SUBJECT), SDO.datePublished))
+    assert not list(graph.objects(URIRef(SUBJECT), SDO.license))
+
+
+def test_parse_no_contacts():
+    data = b"""
+publiccodeYmlVersion: "0.5"
+name: test
+url: https://example.org/test
+legal:
+  license: MIT
+"""
+    graph = PublicCodeParser(subject=SUBJECT).parse(data)
+    assert not list(graph.objects(URIRef(SUBJECT), SDO.author))
+
+
+def test_parse_invalid_yaml():
+    graph = PublicCodeParser(subject=SUBJECT).parse(b"{{invalid yaml")
+    assert len(graph) == 0
+
+
+def test_parse_empty():
+    graph = PublicCodeParser(subject=SUBJECT).parse(b"")
+    assert len(graph) == 0


### PR DESCRIPTION
This pull request adds support for parsing `publiccode.yml` files (following the v0.5.0 standard) to extract metadata, such as upstream repository URLs (when the repo is not a fork) and maintenance contacts, into gimie output. It introduces a new parser, integrates it into the parser selection logic trying to stick closely to how it was done for CFF, and adds tests. 

**PublicCode parser integration:**

* Added a new `PublicCodeParser` in `gimie/parsers/publiccode.py` to extract `isBasedOn` URLs and maintenance contacts from `publiccode.yml` files, mapping them to gimie fields.
* Registered `PublicCodeParser` in the parser registry and updated the parser selection logic to recognize `publiccode.yml` and `publiccode.yaml` files.

**Utilities and identifier consistency:**

* Introduced `sanitize_identifier` in `gimie/utils/uri.py` to generate URL-safe, lowercase identifiers from names, and refactored code to use this function for person URIs (including updating the git extractor). This can also be used by other parsers or extractors (like git.py does now).

**Testing and documentation:**

* Added comprehensive tests for the new parser and its helper functions in `tests/test_publiccode.py`, covering various parsing scenarios and graph assertions.
* Added a `publiccode.yml` file for gimie to the repository for reference and testing. 